### PR TITLE
remove unnecessary --quantization fp8 flag

### DIFF
--- a/docs/DeepSeek/DeepSeek-R1.md
+++ b/docs/DeepSeek/DeepSeek-R1.md
@@ -137,7 +137,6 @@ python -m sglang.launch_server \
   --tool-call-parser deepseekv3 \
   --chat-template examples/chat_template/tool_chat_template_deepseekr1.jinja \
   --tp 8 \
-  --disable-radix-cache
 ```
 
 **Python Example (with Thinking Process):**


### PR DESCRIPTION
For `deepseek-ai/DeepSeek-R1-0528` the default quantization scheme if not specified is `fp8`.  Therefore the flag `--quantization fp8` is not required.