### PR TITLE
Update review-pr and add-model skills from 12-PR audit

### DIFF
--- a/.claude/skills/add-model/SKILL.md
+++ b/.claude/skills/add-model/SKILL.md
@@ -49,7 +49,7 @@ Only include platforms the user has actually tested.
 | A100     | NVIDIA | 80GB   | `lmsysorg/sglang:<ver>` |
 | H100     | NVIDIA | 80GB   | `lmsysorg/sglang:<ver>` |
 | H200     | NVIDIA | 141GB  | `lmsysorg/sglang:<ver>` |
-| B200     | NVIDIA | 183GB  | `lmsysorg/sglang:<ver>` |
+| B200     | NVIDIA | 180GB  | `lmsysorg/sglang:<ver>` |
 | B300     | NVIDIA | 275GB  | `lmsysorg/sglang:<ver>` |
 | MI300X   | AMD    | 192GB  | `lmsysorg/sglang:<ver>-rocm720-mi30x` |
 | MI325X   | AMD    | 256GB  | `lmsysorg/sglang:<ver>-rocm720-mi30x` |
@@ -133,6 +133,16 @@ In config tips, describe `--dp` matching `--tp` as a common pattern, not a requi
 
 **Multiple variants**: Add `modelSize` and/or `quantization` selectors. See `GLM5ConfigGenerator`, `Qwen3CoderConfigGenerator`, `Qwen3NextConfigGenerator` for patterns.
 
+**Platform-required flags**: If a platform requires certain flags to function at all (e.g., AMD MI355X needs `--attention-backend triton`), add them unconditionally for that platform — NOT gated behind optional checkboxes like "Performance Optimizations". Optional optimizations go inside checkbox guards; required-to-work flags go outside.
+
+**No dead code**: Don't define `commandRule` on options if `generateCommand` handles them directly (the rules will never be called). Don't use `getDynamicItems` if the items don't depend on other option values — use static `items` instead. Don't leave unused helper functions.
+
+**No silent ignores**: If a feature (e.g., DP attention) is unsupported on a platform, either disable the UI option or show an explicit message (like a "Work In Progress" note). Never silently drop user selections.
+
+**Scope discipline**: If adding support for one platform, don't accidentally add global flags. Always check conditionals: `if (quantization === 'fp8')` without a hardware guard affects ALL platforms. Be explicit: `if (hardware === 'h200' && quantization === 'fp8')`.
+
+**License accuracy**: Always verify the actual HuggingFace model license before writing the license section. Don't copy from other model docs — licenses vary (Apache 2.0, MIT, community licenses, etc.).
+
 ### Step 4: Add YAML config
 
 Create `data/models/src/<version>/<modelname>.yaml`:
@@ -190,19 +200,26 @@ Can be triggered with `/add-model review`. Also consider running `/review-pr` on
 
 Review the complete documentation for:
 - Nested code block formatting (use ```````` for outer blocks containing ` ``` `)
-- Consistent port numbers across all commands (use 30000, not 8000)
+- Consistent port numbers across all commands, curl examples, and client code (use 30000, not 8000)
+- Launch port matches client/curl `base_url` port on the same page
 - No duplicate deployment commands (reference the one at the top of Section 4)
 - All `TODO` placeholders replaced with actual results
 - ConfigGenerator defaults match the documented deployment command
 - ConfigGenerator `export default` matches the actual class name (common copy-paste bug)
-- All commands use `sglang serve` — no deprecated `python -m sglang.launch_server`
+- All commands use `sglang serve` — no deprecated `python -m sglang.launch_server` or `python3 -m sglang.launch_server`
 - Reasoning mode examples show both thinking-on and thinking-off patterns (for hybrid reasoning models)
 - `modelConfigs` include both `tp` and `mem` values per hardware/quantization
 - DP attention `--dp` value dynamically matches `--tp` in the generator
-- All commands use `sglang serve --model-path` (NOT `python -m sglang.launch_server`)
 - Homepage (`docs/intro.md`) includes the new model entry and matches sidebar order
 - NEW tag count on homepage is 3 or fewer
 - Raw API response objects (e.g., `ChatCompletionMessage(...)`) are formatted into readable structured output (Reasoning/Content/Tool Calls sections)
+- License section matches the actual HuggingFace model license (verify — don't copy from other models)
+- No dead code in ConfigGenerator (unused `commandRule`, unused helper functions, `getDynamicItems` returning static arrays)
+- Platform-required flags are unconditional (not behind optional checkboxes)
+- Unsupported features show explicit messages, not silent no-ops
+- No images hosted on Google Drive (sharing links don't render in markdown)
+- Shell environment blocks use proper placeholders (`export VAR=<your-value>`), not `export VAR=${VAR}` (which is a bash no-op)
+- Grammar and spelling checked in all added documentation text
 
 ## Git Workflow
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -27,11 +27,13 @@ Fetch the diff, run the checklist, report what you find.
 - No stray files (`package-lock.json`, `.claude/settings.local.json`, unrelated `.gitignore` changes)
 - Only expected files: `.md` doc, `src/components/.../index.js`, optional `data/` YAML
 - Files must end with a trailing newline — flag `\ No newline at end of file`
+- Check commit history for unrelated commits (e.g., "Create settings.local.json") that may have been included accidentally
 
 ### 2. Launch command
 - Must use `sglang serve` — flag `python -m sglang.launch_server` (deprecated, issue #33)
 - Applies to docs AND ConfigGenerator `generateCommand`
-- New PRs should fix pre-existing deprecated commands, not pile on more hardware
+- New PRs should fix pre-existing deprecated commands in files they touch, not pile on more hardware
+- Also flag `python3 -m sglang.launch_server` (same issue, just python3 variant)
 
 ### 3. Hardware specs
 
@@ -40,7 +42,7 @@ Fetch the diff, run the checklist, report what you find.
 | A100   | 80GB   |
 | H100   | 80GB   |
 | H200   | 141GB  |
-| B200   | 183GB  |
+| B200   | 180GB  |
 | B300   | 275GB  |
 | MI300X | 192GB  |
 | MI325X | 256GB  |
@@ -49,6 +51,8 @@ Fetch the diff, run the checklist, report what you find.
 
 - TP must make sense: `model_weight_GB / (tp * gpu_mem)` should fit with ~20-30% headroom
 - BF16 ≈ params * 2 GB, FP8 ≈ params * 1 GB, FP4 ≈ params * 0.5 GB
+- For MoE models, use total weight size (all experts), not active params
+- Multi-node configs: verify node count × GPUs × memory is sufficient
 
 ### 4. ConfigGenerator quality
 - Must extend the base `ConfigGenerator` from `../../base/ConfigGenerator` — no custom standalone React components
@@ -63,45 +67,69 @@ Fetch the diff, run the checklist, report what you find.
 - Watch for JS syntax errors (mismatched braces, trailing commas)
 - If a quantization/weight option exists in the UI, it must do something in `generateCommand` — dead options are misleading
 - New hardware should come with `data/models/src/` YAML updates
+- No dead code: unused functions, unreachable `commandRule` properties superseded by `generateCommand`, or `getDynamicItems` that return static arrays
+- No duplicate conditional blocks with identical conditions — consolidate them
+- Platform-required flags (e.g., AMD Triton attention) must be unconditional, not gated behind optional checkboxes
+- Silently ignoring user selections (e.g., DP checkbox does nothing for a platform) is a UX bug — show a message or disable the option
 
 ### 5. Port consistency
 - Use `--port 30000` everywhere (not 8000)
-- Applies to both docs and generated commands
+- Applies to docs, generated commands, curl examples, benchmark commands, and client code (`base_url`)
+- All examples on the same page must use the same port — launch command port must match client/curl port
+- For multi-node configs, shell variable placeholders like `${PORT}` are acceptable but document the expected value
 
 ### 6. Quantization rules
 - FP4 is Blackwell-only (B200/B300) — never AMD
 - BF16 and FP8 work on both NVIDIA and AMD
 - AMD FP4 options must be `disabled: true` in the UI
+- FP8 configs that add `--kv-cache-dtype fp8_e4m3` should note potential accuracy trade-offs
 
 ### 7. Duplicate PRs
 - Another open PR for the same model? Flag it
 - Compare which is more complete (YAML, benchmarks, correct commands)
 - Note merge conflict risk if they touch the same files
+- Same author with overlapping PRs: flag the older one as potentially superseded
 
 ### 8. Sidebar
 - New model → `sidebars.js` must be updated
 - Deleted/renamed doc file → sidebar reference must follow
 - Removed `sidebar_position` frontmatter → flag (affects ordering)
 
-### 9. Links
-- HuggingFace URLs point to the right model
+### 9. Links and factual claims
+- HuggingFace URLs point to the right model — verify the model actually exists
 - No `sgl-project-dev` references (use `sgl-project`)
 - Docker images should come from `lmsysorg/sglang` — flag alternatives like `rocm/sgl-dev`
 - Docs links use `docs.sglang.io` (canonical — `.ai` 301-redirects there)
 - Markdown links well-formed: `[text](url)` not `[text] (url)`
+- Google Drive sharing links will NOT render as images in markdown — must use direct image URLs or host in repo
+- License claims must match the actual HuggingFace model license (common error: saying "Community License" when model is Apache 2.0)
+- Shell placeholders like `export VAR=${VAR}` are bash no-ops — use `export VAR=<placeholder>` or actual example values
 
 ### 10. Scope
 - Do the changes match what the PR title says?
 - Flag global changes hiding behind a platform-specific title (e.g., "H200 FP8" PR that adds `--kv-cache-dtype` to every platform)
+- Check conditionals carefully: `if (quantization === 'fp8')` without a hardware guard affects ALL platforms, not just the one in the title
+- Unmentioned side-fixes (bug fixes, flag renames, casing corrections) should be documented in the PR body
 
 ### 11. Benchmarks
 - Benchmarks use `python3 -m sglang.bench_serving`, not `sglang serve` with benchmark flags
 - Deploy and benchmark are separate steps
+- Benchmark port must match the deployment port in the same section
 
 ### 12. Build
 ```bash
 npm run build
 ```
+
+### 13. Grammar and spelling (docs PRs)
+- Check all added/changed lines for typos, misspellings, and grammar errors
+- Common issues: "recommend" vs "recommended", subject-verb agreement, misspelled technical terms
+- Flag each error with the exact wrong text and correction
+
+### 14. Reviewer feedback
+- Check existing review comments — have prior reviewer requests been addressed?
+- Unresolved requested changes from collaborators should be flagged
+- If a reviewer requested something specific (e.g., accuracy warning), verify it was added
 
 ## Output
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -15,7 +15,7 @@ Fetch the diff, run the checklist, report what you find.
 
 ## Steps
 
-1. `gh pr view <N> --json title,body,files,author,baseRefName,headRefName`
+1. `gh pr view <N> --json title,body,files,author,baseRefName,headRefName,commits,reviews`
 2. `gh pr diff <N>`
 3. `gh pr list --state open --search "<model name>"` (duplicate check)
 4. Run every checklist item against the diff
@@ -127,9 +127,9 @@ npm run build
 - Flag each error with the exact wrong text and correction
 
 ### 14. Reviewer feedback
-- Check existing review comments — have prior reviewer requests been addressed?
+- Check existing review comments from `gh api repos/$(gh repo view --json nameWithOwner -q .nameWithOwner)/pulls/<N>/comments` — have prior reviewer requests been addressed?
 - Unresolved requested changes from collaborators should be flagged
-- If a reviewer requested something specific (e.g., accuracy warning), verify it was added
+- If a reviewer requested something specific (e.g., accuracy warning), verify it was added in the latest diff
 
 ## Output
 


### PR DESCRIPTION
## Summary

- Expands `review-pr` checklist from 12 to 14 items based on issues found while reviewing all 12 open PRs
- Updates `add-model` skill with 5 new rules derived from the same audit
- Fixes B200 memory from 183GB to 180GB (matches NVIDIA spec sheet)

## What changed

**review-pr skill** — new checklist items and enhancements:
- **#13 Grammar/spelling**: check docs PRs for typos (caught 14 in PR #223)
- **#14 Reviewer feedback**: verify prior reviewer requests were addressed (e.g., PR #206 had unresolved accuracy warning request)
- **#4 ConfigGenerator**: dead code detection, duplicate conditional blocks, platform-required flags behind optional checkboxes, silent user selection ignores
- **#5 Port consistency**: now covers curl examples and client `base_url`, not just launch commands (caught mismatches in PR #141 across 5+ files)
- **#9 Links**: Google Drive image detection, license verification, bash no-op placeholder detection
- **#10 Scope**: conditional scope analysis — `if (quantization === 'fp8')` without hardware guard affects all platforms (caught in PR #214)

**add-model skill** — new rules:
- Platform-required flags must be unconditional (not behind optional checkboxes)
- No dead code (`commandRule` superseded by `generateCommand`, static `getDynamicItems`, unused helpers)
- No silent feature ignores (show WIP messages instead)
- Scope discipline (guard conditionals with hardware checks)
- License accuracy (verify HuggingFace, don't copy from other models)

## How these were found

Each new rule maps to a real issue found in the current open PRs:

| Rule | Found in |
|------|----------|
| Triton flags behind checkbox | #213 (MiMo MI355X) |
| Global scope behind specific title | #214 (Qwen3.5), #177 (Qwen3.5) |
| Dead code | #212 (Ring-2.5-1T `commentOut`), #141 (MiniMax `commandRule`) |
| Port mismatch | #141 (5+ files), #223 (DS V3.2) |
| License wrong | #215 (DeepSeek-Math-V2 says Community, actually Apache 2.0) |
| Google Drive image | #223 (DS V3.2) |
| Bash no-op placeholder | #212 (`export MASTER_IP=${MASTER_IP}`) |
| Reviewer feedback ignored | #206 (accuracy warning), #177 (scope + rebase) |
| Grammar/typos | #223 (14 errors), #224 (1 error) |

## Test plan

- [ ] These are Claude Code skill files (markdown), no build impact
- [ ] Review the checklist items for accuracy and completeness