### PR TITLE
Update Qwen3.5 ConfigGenerator for B200 FP4 (NVFP4)

### DIFF
--- a/src/components/autoregressive/MiniMaxM25ConfigGenerator/index.js
+++ b/src/components/autoregressive/MiniMaxM25ConfigGenerator/index.js
@@ -28,15 +28,14 @@ const MiniMaxM25ConfigGenerator = () => {
         title: 'GPU Count',
         getDynamicItems: (values) => {
           const isAMD = values.hardware === 'mi300x' || values.hardware === 'mi325x' || values.hardware === 'mi355x';
-          const isB200 = values.hardware === 'b200';
 
-          // Show 2 GPU option for all hardware, but only enabled for AMD GPUs and B200
+          // Show 2 GPU option for all hardware, but only enabled for AMD GPUs
           return [
             {
               id: '2gpu',
               label: '2',
               default: isAMD,  // Default for all AMD GPUs
-              disabled: !isAMD && !isB200  // Only enabled for AMD GPUs and B200
+              disabled: !isAMD  // Only enabled for AMD GPUs
             },
             {
               id: '4gpu',
@@ -77,11 +76,10 @@ const MiniMaxM25ConfigGenerator = () => {
       const { hardware, gpuCount, thinking, toolcall } = values;
 
       const isAMD = hardware === 'mi300x' || hardware === 'mi325x' || hardware === 'mi355x';
-      const isB200 = hardware === 'b200';
 
-      // Validate 2-GPU configuration (only AMD and B200 support 2 GPUs)
-      if (gpuCount === '2gpu' && !isAMD && !isB200) {
-        return '# Please select compatible hardware\n# 2-GPU requires AMD MI300X/MI325X/MI355X or B200';
+      // Validate 2-GPU configuration (only AMD supports 2 GPUs)
+      if (gpuCount === '2gpu' && !isAMD) {
+        return '# Please select compatible hardware\n# 2-GPU requires AMD MI300X/MI325X/MI355X';
       }
 
       const modelName = `${this.modelFamily}/MiniMax-M2.5`;
@@ -91,19 +89,21 @@ const MiniMaxM25ConfigGenerator = () => {
       cmd += `  --model-path ${modelName}`;
 
       // TP and EP size based on GPU count
-      // NVIDIA (non-B200): EP only for 8-GPU configuration
-      // B200 and AMD: EP=TP for all configurations
+      // NVIDIA: EP only for 8-GPU configuration
+      // AMD: EP=TP for all configurations
       if (gpuCount === '8gpu') {
         cmd += ` \\\n  --tp 8`;
         cmd += ` \\\n  --ep 8`;
       } else if (gpuCount === '4gpu') {
         cmd += ` \\\n  --tp 4`;
-        if (isAMD || isB200) {
+        // Only add EP for AMD GPUs
+        if (isAMD) {
           cmd += ` \\\n  --ep 4`;
         }
       } else if (gpuCount === '2gpu') {
         cmd += ` \\\n  --tp 2`;
-        if (isAMD || isB200) {
+        // Only add EP for AMD GPUs (MI355X only supports 2 GPU)
+        if (isAMD) {
           cmd += ` \\\n  --ep 2`;
         }
       }
@@ -125,11 +125,6 @@ const MiniMaxM25ConfigGenerator = () => {
       if (isAMD) {
         cmd += ` \\\n  --kv-cache-dtype fp8_e4m3`;
         cmd += ` \\\n  --attention-backend triton`;
-      }
-
-      // Add B200-specific configurations (FP8 KV cache)
-      if (isB200) {
-        cmd += ` \\\n  --kv-cache-dtype fp8_e4m3`;
       }
 
       return cmd;

--- a/src/components/autoregressive/MiniMaxM25ConfigGenerator/index.js
+++ b/src/components/autoregressive/MiniMaxM25ConfigGenerator/index.js
@@ -127,10 +127,9 @@ const MiniMaxM25ConfigGenerator = () => {
         cmd += ` \\\n  --attention-backend triton`;
       }
 
-      // Add B200-specific configurations (FP8 KV cache, disable radix cache)
+      // Add B200-specific configurations (FP8 KV cache)
       if (isB200) {
         cmd += ` \\\n  --kv-cache-dtype fp8_e4m3`;
-        cmd += ` \\\n  --disable-radix-cache`;
       }
 
       return cmd;

--- a/src/components/autoregressive/MiniMaxM25ConfigGenerator/index.js
+++ b/src/components/autoregressive/MiniMaxM25ConfigGenerator/index.js
@@ -75,9 +75,8 @@ const MiniMaxM25ConfigGenerator = () => {
     generateCommand: function (values) {
       const { hardware, gpuCount, thinking, toolcall } = values;
 
-      const isAMD = hardware === 'mi300x' || hardware === 'mi325x' || hardware === 'mi355x';
-
       // Validate 2-GPU configuration (only AMD supports 2 GPUs)
+      const isAMD = hardware === 'mi300x' || hardware === 'mi325x' || hardware === 'mi355x';
       if (gpuCount === '2gpu' && !isAMD) {
         return '# Please select compatible hardware\n# 2-GPU requires AMD MI300X/MI325X/MI355X';
       }

--- a/src/components/autoregressive/MiniMaxM25ConfigGenerator/index.js
+++ b/src/components/autoregressive/MiniMaxM25ConfigGenerator/index.js
@@ -28,14 +28,15 @@ const MiniMaxM25ConfigGenerator = () => {
         title: 'GPU Count',
         getDynamicItems: (values) => {
           const isAMD = values.hardware === 'mi300x' || values.hardware === 'mi325x' || values.hardware === 'mi355x';
+          const isB200 = values.hardware === 'b200';
 
-          // Show 2 GPU option for all hardware, but only enabled for AMD GPUs
+          // Show 2 GPU option for all hardware, but only enabled for AMD GPUs and B200
           return [
             {
               id: '2gpu',
               label: '2',
               default: isAMD,  // Default for all AMD GPUs
-              disabled: !isAMD  // Only enabled for AMD GPUs
+              disabled: !isAMD && !isB200  // Only enabled for AMD GPUs and B200
             },
             {
               id: '4gpu',
@@ -75,10 +76,12 @@ const MiniMaxM25ConfigGenerator = () => {
     generateCommand: function (values) {
       const { hardware, gpuCount, thinking, toolcall } = values;
 
-      // Validate 2-GPU configuration (only AMD supports 2 GPUs)
       const isAMD = hardware === 'mi300x' || hardware === 'mi325x' || hardware === 'mi355x';
-      if (gpuCount === '2gpu' && !isAMD) {
-        return '# Please select compatible hardware\n# 2-GPU requires AMD MI300X/MI325X/MI355X';
+      const isB200 = hardware === 'b200';
+
+      // Validate 2-GPU configuration (only AMD and B200 support 2 GPUs)
+      if (gpuCount === '2gpu' && !isAMD && !isB200) {
+        return '# Please select compatible hardware\n# 2-GPU requires AMD MI300X/MI325X/MI355X or B200';
       }
 
       const modelName = `${this.modelFamily}/MiniMax-M2.5`;
@@ -88,21 +91,19 @@ const MiniMaxM25ConfigGenerator = () => {
       cmd += `  --model-path ${modelName}`;
 
       // TP and EP size based on GPU count
-      // NVIDIA: EP only for 8-GPU configuration
-      // AMD: EP=TP for all configurations
+      // NVIDIA (non-B200): EP only for 8-GPU configuration
+      // B200 and AMD: EP=TP for all configurations
       if (gpuCount === '8gpu') {
         cmd += ` \\\n  --tp 8`;
         cmd += ` \\\n  --ep 8`;
       } else if (gpuCount === '4gpu') {
         cmd += ` \\\n  --tp 4`;
-        // Only add EP for AMD GPUs
-        if (isAMD) {
+        if (isAMD || isB200) {
           cmd += ` \\\n  --ep 4`;
         }
       } else if (gpuCount === '2gpu') {
         cmd += ` \\\n  --tp 2`;
-        // Only add EP for AMD GPUs (MI355X only supports 2 GPU)
-        if (isAMD) {
+        if (isAMD || isB200) {
           cmd += ` \\\n  --ep 2`;
         }
       }
@@ -124,6 +125,12 @@ const MiniMaxM25ConfigGenerator = () => {
       if (isAMD) {
         cmd += ` \\\n  --kv-cache-dtype fp8_e4m3`;
         cmd += ` \\\n  --attention-backend triton`;
+      }
+
+      // Add B200-specific configurations (FP8 KV cache, disable radix cache)
+      if (isB200) {
+        cmd += ` \\\n  --kv-cache-dtype fp8_e4m3`;
+        cmd += ` \\\n  --disable-radix-cache`;
       }
 
       return cmd;

--- a/src/components/autoregressive/Qwen35ConfigGenerator/index.js
+++ b/src/components/autoregressive/Qwen35ConfigGenerator/index.js
@@ -147,7 +147,7 @@ const Qwen35ConfigGenerator = () => {
       '397b': {
         h100: { bf16: { tp: 16, mem: 0.8 }, fp8: { tp: 8, mem: 0.8 } },
         h200: { bf16: { tp: 8,  mem: 0.8 }, fp8: { tp: 4, mem: 0.8 } },
-        b200: { bf16: { tp: 8,  mem: 0.8 }, fp8: { tp: 4, mem: 0.8 }, fp4: { tp: 4, mem: 0.8 } },
+        b200: { bf16: { tp: 8,  mem: 0.8 }, fp8: { tp: 4, mem: 0.8 }, fp4: { tp: 4, mem: 0.85 } },
         b300: { bf16: { tp: 4,  mem: 0.8 }, fp8: { tp: 2, mem: 0.8 }, fp4: { tp: 2, mem: 0.8 } },
         mi300x: { bf16: { tp: 8, mem: 0.8 }, fp8: { tp: 4, mem: 0.8 } },
         mi325x: { bf16: { tp: 4, mem: 0.8 }, fp8: { tp: 2, mem: 0.8 } },
@@ -265,8 +265,10 @@ const Qwen35ConfigGenerator = () => {
         }
       });
 
-      // Enable allreduce fusion for all Qwen3.5 configs.
-      cmd += ` \\\n  --enable-flashinfer-allreduce-fusion`;
+      // Enable allreduce fusion for all Qwen3.5 configs (FP4 uses TP=4, not needed per benchmark).
+      if (quantization !== 'fp4') {
+        cmd += ` \\\n  --enable-flashinfer-allreduce-fusion`;
+      }
 
       // Append backend configurations
       if (hardware === 'b200' || hardware === 'b300') {
@@ -287,7 +289,15 @@ const Qwen35ConfigGenerator = () => {
 
       // FP4-specific backend settings
       if (quantization === 'fp4') {
-        cmd += ' \\\n  --moe-runner-backend flashinfer_trtllm \\\n  --fp4-gemm-backend flashinfer_cutlass \\\n  --kv-cache-dtype fp8_e4m3';
+        cmd += ' \\\n  --quantization modelopt_fp4';
+        cmd += ' \\\n  --fp4-gemm-backend flashinfer_cutlass';
+        cmd += ' \\\n  --kv-cache-dtype fp8_e4m3';
+        cmd += ' \\\n  --moe-runner-backend flashinfer_trtllm';
+        cmd += ' \\\n  --chunked-prefill-size 32768';
+        cmd += ' \\\n  --max-prefill-tokens 32768';
+        cmd += ' \\\n  --max-running-requests 128';
+        cmd += ' \\\n  --stream-interval 30';
+        cmd += ' \\\n  --disable-radix-cache';
       }
 
       // Add memory fraction last

--- a/src/components/autoregressive/Qwen35ConfigGenerator/index.js
+++ b/src/components/autoregressive/Qwen35ConfigGenerator/index.js
@@ -281,8 +281,10 @@ const Qwen35ConfigGenerator = () => {
         cmd += ` \\\n  --tokenizer-worker-num 6`;
       }
 
-      // Enable allreduce fusion for all Qwen3.5 configs.
-      cmd += ` \\\n  --enable-flashinfer-allreduce-fusion`;
+      // Enable allreduce fusion for all Qwen3.5 configs (skip for FP4: benchmark only enables this for TP≥8).
+      if (quantization !== 'fp4') {
+        cmd += ` \\\n  --enable-flashinfer-allreduce-fusion`;
+      }
 
       // H200 FP8-specific optimizations
       if (hardware === 'h200' && quantization === 'fp8') {


### PR DESCRIPTION
## Summary

Updates `Qwen35ConfigGenerator` with validated flags for Qwen3.5-397B-A17B on B200 with NVFP4 quantization.

Based on SemiAnalysisAI/InferenceX#820.

## Changes

- **`mem-fraction-static` 0.85** for B200 FP4 (benchmark uses 0.85, not 0.8)
- **Add `--quantization modelopt_fp4`** — required flag that was missing entirely
- **Add `--chunked-prefill-size 32768` / `--max-prefill-tokens 32768`** — FP4-specific prefill tuning
- **Add `--max-running-requests 128` / `--stream-interval 30`** — FP4-specific throughput settings
- **Add `--disable-radix-cache`** — always required for FP4 (benchmark always sets this)
- **Skip `--enable-flashinfer-allreduce-fusion` for FP4** — benchmark only enables this for TP≥8; B200 FP4 uses TP=4

## Test plan

- [ ] Select Model: 397B, Hardware: B200, Quantization: FP4 in the config generator
- [ ] Verify generated command includes `--quantization modelopt_fp4`, `--fp4-gemm-backend flashinfer_cutlass`, `--kv-cache-dtype fp8_e4m3`, `--moe-runner-backend flashinfer_trtllm`
- [ ] Verify `--chunked-prefill-size 32768`, `--max-prefill-tokens 32768`, `--max-running-requests 128`, `--stream-interval 30`, `--disable-radix-cache` are present
- [ ] Verify `--enable-flashinfer-allreduce-fusion` is NOT present for FP4
- [ ] Verify `--mem-fraction-static 0.85`
- [ ] Verify B200 BF16/FP8 still produce `--enable-flashinfer-allreduce-fusion`