### PR TITLE
Remove --kv-cache-dtype fp8_e4m3 from Qwen3.5 and GLM-5 FP8 configs

### DIFF
--- a/docs/autoregressive/GLM/GLM-5.md
+++ b/docs/autoregressive/GLM/GLM-5.md
@@ -53,15 +53,15 @@ import GLM5ConfigGenerator from '@site/src/components/autoregressive/GLM5ConfigG
 | MI300X/MI325X | — | tp=8 |
 | MI355X   | — | tp=8 |
 
-:::caution FP8 Accuracy
-FP8 quantization (`--quantization fp8`, `--kv-cache-dtype fp8_e4m3`) reduces memory usage and improves throughput but may cause a slight accuracy drop compared to BF16. Evaluate on your target task before deploying in accuracy-sensitive applications.
-:::
-
-- **B200 (FP8)**: Use `--ep 1 --attention-backend nsa --nsa-decode-backend trtllm --nsa-prefill-backend trtllm --moe-runner-backend flashinfer_trtllm --enable-flashinfer-allreduce-fusion` for optimized NSA and MoE backends on Blackwell. Also add `--kv-cache-dtype fp8_e4m3 --quantization fp8` for FP8 KV cache and weight quantization.
+- **B200 (FP8)**: Use `--ep 1 --attention-backend nsa --nsa-decode-backend trtllm --nsa-prefill-backend trtllm --moe-runner-backend flashinfer_trtllm --enable-flashinfer-allreduce-fusion` for optimized NSA and MoE backends on Blackwell. Also add `--quantization fp8` for FP8 weight quantization.
 
 - **AMD GPUs**: Use `--nsa-prefill-backend tilelang --nsa-decode-backend tilelang` for the NSA attention backend. Add `--chunked-prefill-size 131072` and `--watchdog-timeout 1200` (20 minutes for weight loading). EAGLE speculative decoding is not currently supported on AMD for GLM-5.
 - For other configuration tips, please refer to [DeepSeek V3.2 documentation](https://docs.sglang.io/basic_usage/deepseek_v32.html). GLM-5 and DeepSeek V3.2 share the same model structure, so the optimization techniques between these two models are also common (MTP, DSA kernel, Context Parallel...).
 - Use `--json-model-override-args '{"index_topk_pattern": "FFSFSSSFSSFFFSSSFFFSFSSSSSSFFSFFSFFSSFFFFFFSFFFFFSFFSSSSSSFSFFFSFSSSFSFFSFFSSS"}'` for GLM-5-FP8 if you want to enable the [IndexCache](https://github.com/THUDM/IndexCache) method. This feature is supported through [this PR](https://github.com/sgl-project/sglang/pull/21405) and introduces only a small accuracy loss. However, if you are running rigorous accuracy evaluations, it is not recommended to enable this feature.
+
+:::caution FP8 KV Cache
+`--kv-cache-dtype fp8_e4m3` quantizes the KV cache to FP8 at runtime. Since these FP8 model checkpoints do not include pre-calibrated KV cache scaling factors, SGLang defaults to a scale of 1.0, which may cause noticeable accuracy degradation on reasoning-heavy tasks. It is not included in the generated commands above; add it manually only if memory constraints require the trade-off.
+:::
 
 ## 4. Model Invocation
 

--- a/docs/autoregressive/Qwen/Qwen3.5.md
+++ b/docs/autoregressive/Qwen/Qwen3.5.md
@@ -106,6 +106,10 @@ import Qwen35ConfigGenerator from '@site/src/components/autoregressive/Qwen35Con
 | MI325X   | 256GB  | 4       | 2      | N/A             |
 | MI355X   | 288GB  | 4       | 2      | N/A             |
 
+:::caution FP8 KV Cache
+`--kv-cache-dtype fp8_e4m3` quantizes the KV cache to FP8 at runtime. Since these FP8 model checkpoints do not include pre-calibrated KV cache scaling factors, SGLang defaults to a scale of 1.0, which may cause noticeable accuracy degradation on reasoning-heavy tasks. It is not included in the generated commands above; add it manually only if memory constraints require the trade-off.
+:::
+
 ## 4. Model Invocation
 
 **NVIDIA:**

--- a/src/components/autoregressive/GLM5ConfigGenerator/index.js
+++ b/src/components/autoregressive/GLM5ConfigGenerator/index.js
@@ -166,7 +166,6 @@ const GLM5ConfigGenerator = () => {
       // B200 FP8: all optimized flags consolidated
       if (hardware === 'b200' && effectiveQuant === 'fp8') {
         cmd += ' \\\n  --ep 1';
-        cmd += ' \\\n  --kv-cache-dtype fp8_e4m3';
         cmd += ' \\\n  --quantization fp8';
         cmd += ' \\\n  --attention-backend nsa';
         cmd += ' \\\n  --nsa-decode-backend trtllm';

--- a/src/components/autoregressive/Qwen35ConfigGenerator/index.js
+++ b/src/components/autoregressive/Qwen35ConfigGenerator/index.js
@@ -269,11 +269,6 @@ const Qwen35ConfigGenerator = () => {
         }
       });
 
-      // FP8 KV cache dtype (NVIDIA only)
-      if (quantization === 'fp8' && !amdGpus.includes(hardware)) {
-        cmd += ` \\\n  --kv-cache-dtype fp8_e4m3`;
-      }
-
       // Chunked prefill tuning for H200 FP8 + MTP (validated on H200 only)
       if (hardware === 'h200' && quantization === 'fp8' && speculative === 'enabled') {
         cmd += ` \\\n  --max-running-requests 128`;
@@ -289,7 +284,6 @@ const Qwen35ConfigGenerator = () => {
       // H200 FP8-specific optimizations
       if (hardware === 'h200' && quantization === 'fp8') {
         cmd += ` \\\n  --attention-backend flashinfer`;
-        cmd += ` \\\n  --kv-cache-dtype fp8_e4m3`;
         if (MOE_MODELS.has(model)) {
           cmd += ` \\\n  --mamba-ssm-dtype bfloat16`;
         }


### PR DESCRIPTION
The Qwen3.5-FP8 and GLM-5-FP8 checkpoints only quantize model weights — they do not include pre-calibrated KV cache scaling factors (`k_scale`/`v_scale`). When `--kv-cache-dtype fp8_e4m3` is passed without calibrated scales, SGLang falls back to a scale of 1.0 (with a warning), which can cause noticeable accuracy degradation on reasoning-heavy tasks.

Changes:

* Remove `--kv-cache-dtype fp8_e4m3` from `Qwen35ConfigGenerator` (NVIDIA FP8 paths) and `GLM5ConfigGenerator` (B200 FP8 path); FP4 paths are unaffected
* Add a :::caution note in both docs explaining why the flag is omitted and when to add it manually