### PR TITLE
Update Qwen3 tool-call-parser from qwen25 to qwen

### DIFF
--- a/docs/autoregressive/Qwen/Qwen3.md
+++ b/docs/autoregressive/Qwen/Qwen3.md
@@ -159,7 +159,7 @@ Qwen3 supports tool calling capabilities. Enable the tool call parser:
 python -m sglang.launch_server \
   --model Qwen/Qwen3-235B-A22B-Thinking-2507 \
   --reasoning-parser qwen3 \
-  --tool-call-parser qwen25 \
+  --tool-call-parser qwen \
   --tp 8 \
   --host 0.0.0.0 \
   --port 8000

--- a/src/components/autoregressive/Qwen3ConfigGenerator/index.js
+++ b/src/components/autoregressive/Qwen3ConfigGenerator/index.js
@@ -78,7 +78,7 @@ const Qwen3ConfigGenerator = () => {
           { id: 'disabled', label: 'Disabled', default: true },
           { id: 'enabled', label: 'Enabled', default: false }
         ],
-        commandRule: (value) => value === 'enabled' ? '--tool-call-parser qwen25' : null
+        commandRule: (value) => value === 'enabled' ? '--tool-call-parser qwen' : null
       }
     },
 


### PR DESCRIPTION
The qwen25 tool-call-parser was deprecated (sgl-project/sglang#11223) in favor of qwen. This PR updates the Qwen3 documentation and config generator to use the current name.