### PR TITLE
Update Kimi-K2 H200 multi-node launch commands and use sglang serve

### DIFF
--- a/docs/autoregressive/Moonshotai/Kimi-K2.md
+++ b/docs/autoregressive/Moonshotai/Kimi-K2.md
@@ -51,7 +51,7 @@ See [Basic API Usage](https://docs.sglang.ai/basic_usage/send_request.html).
 Enable reasoning parser for Kimi-K2-Thinking:
 
 ```shell
-python -m sglang.launch_server \
+sglang serve \
   --model moonshotai/Kimi-K2-Thinking \
   --reasoning-parser kimi_k2 \
   --tp 8 \
@@ -172,7 +172,7 @@ Kimi-K2-Instruct and Kimi-K2-Thinking support tool calling capabilities. Enable 
 **Deployment Command:**
 
 ```shell
-python -m sglang.launch_server \
+sglang serve \
   --model moonshotai/Kimi-K2-Instruct \
   --tool-call-parser kimi_k2 \
   --tp 8 \
@@ -352,7 +352,7 @@ We use SGLang's built-in benchmarking tool to conduct performance evaluation on 
 - Model Deployment Command:
 
 ```shell
-python3 -m sglang.launch_server \
+sglang serve \
     --model-path moonshotai/Kimi-K2-Instruct \
     --tp 8 \
     --dp 4 \
@@ -420,7 +420,7 @@ Max ITL (ms):                            19.94
 - Model Deployment Command:
 
 ```shell
-python3 -m sglang.launch_server \
+sglang serve \
     --model-path moonshotai/Kimi-K2-Instruct \
     --tp 8 \
     --dp 4 \
@@ -491,7 +491,7 @@ Max ITL (ms):                            1703.21
 - Server Command
 
 ```shell
-python3 -m sglang.launch_server \
+sglang serve \
     --model-path moonshotai/Kimi-K2-Instruct \
     --tp 8 \
     --dp 4 \

--- a/src/components/autoregressive/KimiK2ConfigGenerator/index.js
+++ b/src/components/autoregressive/KimiK2ConfigGenerator/index.js
@@ -72,8 +72,44 @@ const KimiK2ConfigGenerator = () => {
       };
 
       const modelName = `${this.modelFamily}/${modelMap[modelname]}`;
+      const strategyArray = Array.isArray(strategy) ? strategy : [];
 
-      let cmd = 'python3 -m sglang.launch_server \\\n';
+      // H200 + DP attention: 2-node deployment
+      if (hardware === 'h200' && strategyArray.includes('dp')) {
+        const buildNodeCmd = (nodeRank, isLeader) => {
+          const args = [
+            `--model-path ${modelName}`,
+            `--tp 16`,
+            `--dp-size 2`,
+            `--enable-dp-attention`,
+            `--dist-init-addr $MASTER_IP:50000`,
+            `--nnodes 2`,
+            `--node-rank ${nodeRank}`,
+            `--trust-remote-code`,
+          ];
+          if (strategyArray.includes('ep')) {
+            args.push(
+              `--ep 16`,
+              `--enable-dp-lm-head`,
+              `--moe-a2a-backend deepep`,
+              `--moe-runner-backend deep_gemm`,
+              `--moe-dense-tp-size 1`,
+              `--deepep-mode auto`,
+            );
+          }
+          if (toolcall === 'enabled') args.push(`--tool-call-parser kimi_k2`);
+          if (reasoning === 'enabled') args.push(`--reasoning-parser kimi_k2`);
+          if (isLeader) {
+            args.push(`--host 0.0.0.0`);
+            args.push(`--port 30000`);
+          }
+          return `sglang serve \\\n  ` + args.join(` \\\n  `);
+        };
+        return `# Node 0\n${buildNodeCmd(0, true)}\n\n# Node 1\n${buildNodeCmd(1, false)}`;
+      }
+
+      // Single-node deployment
+      let cmd = 'sglang serve \\\n';
 
       if (hardware === 'mi300x' || hardware === 'mi325x' || hardware === 'mi355x') {
         cmd = 'SGLANG_ROCM_FUSED_DECODE_MLA=0 ' + cmd;
@@ -81,8 +117,6 @@ const KimiK2ConfigGenerator = () => {
 
       cmd += `  --model-path ${modelName}`;
 
-      // Strategy configurations
-      const strategyArray = Array.isArray(strategy) ? strategy : [];
       // TP is mandatory
       cmd += ` \\\n  --tp 8`;
       if (strategyArray.includes('dp')) {


### PR DESCRIPTION
## Summary

- Replace all `python[3] -m sglang.launch_server` with `sglang serve` in `Kimi-K2.md` (5 occurrences)
- Config generator now emits 2-node commands (Node 0 / Node 1) for H200 + DP attention, matching the LWS leader/worker format (`--tp 16`, `--dp-size 2`, `--enable-dp-attention`, `--dist-init-addr $MASTER_IP:50000`, `--nnodes 2`, `--node-rank`)
- When EP is also selected on H200 + DP, both nodes include `--ep 16 --enable-dp-lm-head --moe-a2a-backend deepep --moe-runner-backend deep_gemm --moe-dense-tp-size 1 --deepep-mode auto`

## Test plan

- [ ] Select H200 + DP attention in the config generator → verify 2-node command output
- [ ] Select H200 + DP attention + EP → verify EP flags appear on both nodes
- [ ] Select any other hardware + DP → verify single-node `--dp 4 --enable-dp-attention` command
- [ ] Verify no `python -m sglang.launch_server` references remain in `Kimi-K2.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)