### PR TITLE
AMD Qwen3.5 FP4 (MXFP4) Support

### DIFF
--- a/data/models/generated/v0.5.10/qwen35.yaml
+++ b/data/models/generated/v0.5.10/qwen35.yaml
@@ -1,0 +1,817 @@
+vendor: qwen
+families:
+- name: Qwen3.5
+  description: Qwen3.5 397B (17B active) MoE VLM with hybrid reasoning, tool calling, and multimodal capabilities
+  models:
+  - name: Qwen3.5-397B-A17B
+    model_path: Qwen/Qwen3.5-397B-A17B
+    attributes:
+      llm:
+        thinking_capability: hybrid
+        tool_parser: qwen3_coder
+        reasoning_parser: qwen3
+        chat_template: null
+    hardware:
+      H100:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: bf16
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 16
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args: []
+          prefill: null
+          decode: null
+        - name: speculative-mtp
+          attributes:
+            nodes: single
+            optimization: low-latency
+            quantization: bf16
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 16
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --speculative-algo
+            - NEXTN
+            - --speculative-num-steps
+            - '3'
+            - --speculative-eagle-topk
+            - '1'
+            - --speculative-num-draft-tokens
+            - '4'
+          prefill: null
+          decode: null
+      H200:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: bf16
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args: []
+          prefill: null
+          decode: null
+        - name: speculative-mtp
+          attributes:
+            nodes: single
+            optimization: low-latency
+            quantization: bf16
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --speculative-algo
+            - NEXTN
+            - --speculative-num-steps
+            - '3'
+            - --speculative-eagle-topk
+            - '1'
+            - --speculative-num-draft-tokens
+            - '4'
+          prefill: null
+          decode: null
+      B200:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: bf16
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args: []
+          prefill: null
+          decode: null
+        - name: speculative-mtp
+          attributes:
+            nodes: single
+            optimization: low-latency
+            quantization: bf16
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --speculative-algo
+            - NEXTN
+            - --speculative-num-steps
+            - '3'
+            - --speculative-eagle-topk
+            - '1'
+            - --speculative-num-draft-tokens
+            - '4'
+          prefill: null
+          decode: null
+      MI300X:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: bf16
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --trust-remote-code
+            - --attention-backend
+            - aiter
+            - --model-loader-extra-config
+            - '{"enable_multithread_load": true}'
+            - --watchdog-timeout
+            - '1200'
+            - --disable-radix-cache
+          prefill: null
+          decode: null
+        - name: speculative-mtp
+          attributes:
+            nodes: single
+            optimization: low-latency
+            quantization: bf16
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --trust-remote-code
+            - --attention-backend
+            - aiter
+            - --model-loader-extra-config
+            - '{"enable_multithread_load": true}'
+            - --watchdog-timeout
+            - '1200'
+            - --disable-radix-cache
+            - --speculative-algo
+            - NEXTN
+            - --speculative-num-steps
+            - '3'
+            - --speculative-eagle-topk
+            - '1'
+            - --speculative-num-draft-tokens
+            - '4'
+          prefill: null
+          decode: null
+      MI325X:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: bf16
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 4
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --trust-remote-code
+            - --attention-backend
+            - aiter
+            - --model-loader-extra-config
+            - '{"enable_multithread_load": true}'
+            - --watchdog-timeout
+            - '1200'
+            - --disable-radix-cache
+          prefill: null
+          decode: null
+        - name: speculative-mtp
+          attributes:
+            nodes: single
+            optimization: low-latency
+            quantization: bf16
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 4
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --trust-remote-code
+            - --attention-backend
+            - aiter
+            - --model-loader-extra-config
+            - '{"enable_multithread_load": true}'
+            - --watchdog-timeout
+            - '1200'
+            - --disable-radix-cache
+            - --speculative-algo
+            - NEXTN
+            - --speculative-num-steps
+            - '3'
+            - --speculative-eagle-topk
+            - '1'
+            - --speculative-num-draft-tokens
+            - '4'
+          prefill: null
+          decode: null
+      MI355X:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: bf16
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 4
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --trust-remote-code
+            - --attention-backend
+            - aiter
+            - --model-loader-extra-config
+            - '{"enable_multithread_load": true}'
+            - --watchdog-timeout
+            - '1200'
+            - --disable-radix-cache
+          prefill: null
+          decode: null
+        - name: speculative-mtp
+          attributes:
+            nodes: single
+            optimization: low-latency
+            quantization: bf16
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 4
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --trust-remote-code
+            - --attention-backend
+            - aiter
+            - --model-loader-extra-config
+            - '{"enable_multithread_load": true}'
+            - --watchdog-timeout
+            - '1200'
+            - --disable-radix-cache
+            - --speculative-algo
+            - NEXTN
+            - --speculative-num-steps
+            - '3'
+            - --speculative-eagle-topk
+            - '1'
+            - --speculative-num-draft-tokens
+            - '4'
+          prefill: null
+          decode: null
+  - name: Qwen3.5-397B-A17B-FP8
+    model_path: Qwen/Qwen3.5-397B-A17B-FP8
+    attributes:
+      llm:
+        thinking_capability: hybrid
+        tool_parser: qwen3_coder
+        reasoning_parser: qwen3
+        chat_template: null
+    hardware:
+      H100:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: fp8
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args: []
+          prefill: null
+          decode: null
+        - name: speculative-mtp
+          attributes:
+            nodes: single
+            optimization: low-latency
+            quantization: fp8
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --speculative-algo
+            - NEXTN
+            - --speculative-num-steps
+            - '3'
+            - --speculative-eagle-topk
+            - '1'
+            - --speculative-num-draft-tokens
+            - '4'
+          prefill: null
+          decode: null
+      H200:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: fp8
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: null
+            ep: 8
+            enable_dp_attention: null
+            extra_args: []
+          prefill: null
+          decode: null
+        - name: speculative-mtp
+          attributes:
+            nodes: single
+            optimization: low-latency
+            quantization: fp8
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: null
+            ep: 8
+            enable_dp_attention: null
+            extra_args:
+            - --speculative-algo
+            - NEXTN
+            - --speculative-num-steps
+            - '3'
+            - --speculative-eagle-topk
+            - '1'
+            - --speculative-num-draft-tokens
+            - '4'
+          prefill: null
+          decode: null
+      B200:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: fp8
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 4
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args: []
+          prefill: null
+          decode: null
+        - name: speculative-mtp
+          attributes:
+            nodes: single
+            optimization: low-latency
+            quantization: fp8
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 4
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --speculative-algo
+            - NEXTN
+            - --speculative-num-steps
+            - '3'
+            - --speculative-eagle-topk
+            - '1'
+            - --speculative-num-draft-tokens
+            - '4'
+          prefill: null
+          decode: null
+      B300:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: fp8
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 2
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args: []
+          prefill: null
+          decode: null
+        - name: speculative-mtp
+          attributes:
+            nodes: single
+            optimization: low-latency
+            quantization: fp8
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 2
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --speculative-algo
+            - NEXTN
+            - --speculative-num-steps
+            - '3'
+            - --speculative-eagle-topk
+            - '1'
+            - --speculative-num-draft-tokens
+            - '4'
+          prefill: null
+          decode: null
+      MI300X:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: fp8
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 4
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --trust-remote-code
+            - --attention-backend
+            - aiter
+            - --model-loader-extra-config
+            - '{"enable_multithread_load": true}'
+            - --watchdog-timeout
+            - '1200'
+            - --disable-radix-cache
+          prefill: null
+          decode: null
+        - name: speculative-mtp
+          attributes:
+            nodes: single
+            optimization: low-latency
+            quantization: fp8
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 4
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --trust-remote-code
+            - --attention-backend
+            - aiter
+            - --model-loader-extra-config
+            - '{"enable_multithread_load": true}'
+            - --watchdog-timeout
+            - '1200'
+            - --disable-radix-cache
+            - --speculative-algo
+            - NEXTN
+            - --speculative-num-steps
+            - '3'
+            - --speculative-eagle-topk
+            - '1'
+            - --speculative-num-draft-tokens
+            - '4'
+          prefill: null
+          decode: null
+      MI325X:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: fp8
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 2
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --trust-remote-code
+            - --attention-backend
+            - aiter
+            - --model-loader-extra-config
+            - '{"enable_multithread_load": true}'
+            - --watchdog-timeout
+            - '1200'
+            - --disable-radix-cache
+          prefill: null
+          decode: null
+        - name: speculative-mtp
+          attributes:
+            nodes: single
+            optimization: low-latency
+            quantization: fp8
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 2
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --trust-remote-code
+            - --attention-backend
+            - aiter
+            - --model-loader-extra-config
+            - '{"enable_multithread_load": true}'
+            - --watchdog-timeout
+            - '1200'
+            - --disable-radix-cache
+            - --speculative-algo
+            - NEXTN
+            - --speculative-num-steps
+            - '3'
+            - --speculative-eagle-topk
+            - '1'
+            - --speculative-num-draft-tokens
+            - '4'
+          prefill: null
+          decode: null
+      MI355X:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: fp8
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 2
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --trust-remote-code
+            - --attention-backend
+            - aiter
+            - --model-loader-extra-config
+            - '{"enable_multithread_load": true}'
+            - --watchdog-timeout
+            - '1200'
+            - --disable-radix-cache
+          prefill: null
+          decode: null
+        - name: speculative-mtp
+          attributes:
+            nodes: single
+            optimization: low-latency
+            quantization: fp8
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 2
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --trust-remote-code
+            - --attention-backend
+            - aiter
+            - --model-loader-extra-config
+            - '{"enable_multithread_load": true}'
+            - --watchdog-timeout
+            - '1200'
+            - --disable-radix-cache
+            - --speculative-algo
+            - NEXTN
+            - --speculative-num-steps
+            - '3'
+            - --speculative-eagle-topk
+            - '1'
+            - --speculative-num-draft-tokens
+            - '4'
+          prefill: null
+          decode: null
+  - name: Qwen3.5-397B-A17B-NVFP4
+    model_path: nvidia/Qwen3.5-397B-A17B-NVFP4
+    attributes:
+      llm:
+        thinking_capability: hybrid
+        tool_parser: qwen3_coder
+        reasoning_parser: qwen3
+        chat_template: null
+    hardware:
+      B200:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: fp4
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 4
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --attention-backend
+            - trtllm_mha
+            - --moe-runner-backend
+            - flashinfer_trtllm
+            - --fp4-gemm-backend
+            - flashinfer_cutlass
+          prefill: null
+          decode: null
+        - name: speculative-mtp
+          attributes:
+            nodes: single
+            optimization: low-latency
+            quantization: fp4
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 4
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --attention-backend
+            - trtllm_mha
+            - --moe-runner-backend
+            - flashinfer_trtllm
+            - --fp4-gemm-backend
+            - flashinfer_cutlass
+            - --speculative-algo
+            - NEXTN
+            - --speculative-num-steps
+            - '3'
+            - --speculative-eagle-topk
+            - '1'
+            - --speculative-num-draft-tokens
+            - '4'
+          prefill: null
+          decode: null
+      B300:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: fp4
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 2
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --attention-backend
+            - trtllm_mha
+            - --moe-runner-backend
+            - flashinfer_trtllm
+            - --fp4-gemm-backend
+            - flashinfer_cutlass
+          prefill: null
+          decode: null
+        - name: speculative-mtp
+          attributes:
+            nodes: single
+            optimization: low-latency
+            quantization: fp4
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 2
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --attention-backend
+            - trtllm_mha
+            - --moe-runner-backend
+            - flashinfer_trtllm
+            - --fp4-gemm-backend
+            - flashinfer_cutlass
+            - --speculative-algo
+            - NEXTN
+            - --speculative-num-steps
+            - '3'
+            - --speculative-eagle-topk
+            - '1'
+            - --speculative-num-draft-tokens
+            - '4'
+          prefill: null
+          decode: null
+  - name: Qwen3.5-397B-A17B-MXFP4
+    model_path: amd/Qwen3.5-397B-A17B-MXFP4
+    attributes:
+      llm:
+        thinking_capability: hybrid
+        tool_parser: qwen3_coder
+        reasoning_parser: qwen3
+        chat_template: null
+    hardware:
+      MI355X:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: fp4
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 2
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --trust-remote-code
+            - --attention-backend
+            - aiter
+            - --model-loader-extra-config
+            - '{"enable_multithread_load": true}'
+            - --watchdog-timeout
+            - '1200'
+            - --disable-radix-cache
+          prefill: null
+          decode: null
+        - name: speculative-mtp
+          attributes:
+            nodes: single
+            optimization: low-latency
+            quantization: fp4
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 2
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --trust-remote-code
+            - --attention-backend
+            - aiter
+            - --model-loader-extra-config
+            - '{"enable_multithread_load": true}'
+            - --watchdog-timeout
+            - '1200'
+            - --disable-radix-cache
+            - --speculative-algo
+            - NEXTN
+            - --speculative-num-steps
+            - '3'
+            - --speculative-eagle-topk
+            - '1'
+            - --speculative-num-draft-tokens
+            - '4'
+          prefill: null
+          decode: null

--- a/data/models/src/v0.5.10/qwen35.yaml
+++ b/data/models/src/v0.5.10/qwen35.yaml
@@ -1,0 +1,172 @@
+# Qwen3.5 Model Configurations (Simplified Format)
+# This file is compiled to data/models/generated/v0.5.10/qwen35.yaml
+#
+# GPU requirements (BF16):
+#   H100: tp=16 (model ~800GB in BF16, each rank needs ~100GB > 80GB)
+#   H200: tp=8
+#   B200: tp=8
+#   MI300X: tp=8
+#   MI325X: tp=4
+#   MI355X: tp=4
+#
+# GPU requirements (FP8):
+#   H100: tp=8 (model ~400GB in FP8, each rank needs ~50GB < 80GB)
+#   H200: tp=8, ep=8
+#   B200: tp=4
+#   B300: tp=2
+#   MI300X: tp=4
+#   MI325X: tp=2
+#   MI355X: tp=2
+#
+# GPU requirements (FP4):
+#   B200 (183GB) tp=4, B300 (275GB) tp=2 - FP4 requires Blackwell architecture
+#   MI355X (288GB) tp=2 - AMD FP4 support
+
+vendor: qwen
+
+defaults:
+  hardware:
+    H100: { tp: 16 }
+    H200: { tp: 8 }
+    B200: { tp: 8 }
+    MI300X:
+      tp: 8
+      extra_args:
+        - --trust-remote-code
+        - --attention-backend
+        - aiter
+        - --model-loader-extra-config
+        - '{"enable_multithread_load": true}'
+        - --watchdog-timeout
+        - "1200"
+        - --disable-radix-cache
+    MI325X:
+      tp: 4
+      extra_args:
+        - --trust-remote-code
+        - --attention-backend
+        - aiter
+        - --model-loader-extra-config
+        - '{"enable_multithread_load": true}'
+        - --watchdog-timeout
+        - "1200"
+        - --disable-radix-cache
+    MI355X:
+      tp: 4
+      extra_args:
+        - --trust-remote-code
+        - --attention-backend
+        - aiter
+        - --model-loader-extra-config
+        - '{"enable_multithread_load": true}'
+        - --watchdog-timeout
+        - "1200"
+        - --disable-radix-cache
+  configurations:
+    - name: default
+      nodes: single
+      optimization: balanced
+    - name: speculative-mtp
+      nodes: single
+      optimization: low-latency
+      extra_args:
+        - --speculative-algo
+        - NEXTN
+        - --speculative-num-steps
+        - "3"
+        - --speculative-eagle-topk
+        - "1"
+        - --speculative-num-draft-tokens
+        - "4"
+
+families:
+  - name: Qwen3.5
+    description: Qwen3.5 397B (17B active) MoE VLM with hybrid reasoning, tool calling, and multimodal capabilities
+    llm:
+      thinking_capability: hybrid
+      tool_parser: qwen3_coder
+      reasoning_parser: qwen3
+
+    models:
+      - name: Qwen3.5-397B-A17B
+        quantization: bf16
+
+      - name: Qwen3.5-397B-A17B-FP8
+        quantization: fp8
+        hardware:
+          H100: { tp: 8 }
+          H200: { tp: 8, ep: 8 }
+          B200: { tp: 4 }
+          B300: { tp: 2 }
+          MI300X:
+            tp: 4
+            extra_args:
+              - --trust-remote-code
+              - --attention-backend
+              - aiter
+              - --model-loader-extra-config
+              - '{"enable_multithread_load": true}'
+              - --watchdog-timeout
+              - "1200"
+              - --disable-radix-cache
+          MI325X:
+            tp: 2
+            extra_args:
+              - --trust-remote-code
+              - --attention-backend
+              - aiter
+              - --model-loader-extra-config
+              - '{"enable_multithread_load": true}'
+              - --watchdog-timeout
+              - "1200"
+              - --disable-radix-cache
+          MI355X:
+            tp: 2
+            extra_args:
+              - --trust-remote-code
+              - --attention-backend
+              - aiter
+              - --model-loader-extra-config
+              - '{"enable_multithread_load": true}'
+              - --watchdog-timeout
+              - "1200"
+              - --disable-radix-cache
+
+      - name: Qwen3.5-397B-A17B-NVFP4
+        quantization: fp4
+        model_path: nvidia/Qwen3.5-397B-A17B-NVFP4
+        hardware:
+          B200:
+            tp: 4
+            extra_args:
+              - --attention-backend
+              - trtllm_mha
+              - --moe-runner-backend
+              - flashinfer_trtllm
+              - --fp4-gemm-backend
+              - flashinfer_cutlass
+          B300:
+            tp: 2
+            extra_args:
+              - --attention-backend
+              - trtllm_mha
+              - --moe-runner-backend
+              - flashinfer_trtllm
+              - --fp4-gemm-backend
+              - flashinfer_cutlass
+
+      - name: Qwen3.5-397B-A17B-MXFP4
+        quantization: fp4
+        model_path: amd/Qwen3.5-397B-A17B-MXFP4
+        hardware:
+          MI355X:
+            tp: 2
+            extra_args:
+              - --trust-remote-code
+              - --attention-backend
+              - aiter
+              - --model-loader-extra-config
+              - '{"enable_multithread_load": true}'
+              - --watchdog-timeout
+              - "1200"
+              - --disable-radix-cache

--- a/docs/autoregressive/Qwen/Qwen3.5.md
+++ b/docs/autoregressive/Qwen/Qwen3.5.md
@@ -151,7 +151,7 @@ sglang serve \
   --host 0.0.0.0 \
   --port 30000
 ```
-> **Note:** TP8 works on all MI GPUs. Minimum TP for MI325X/MI355X: BF16 uses --tp 4, FP8 uses --tp 2. MI355X also supports FP4 with --tp 2 using `amd/Qwen3.5-397B-A17B-MXFP4`.
+> **Note:** TP8 works on all MI GPUs. For MI325X/MI355X, you can use --tp 4 as the minimum requirement.
 
 ### 4.1 Basic Usage
 

--- a/docs/autoregressive/Qwen/Qwen3.5.md
+++ b/docs/autoregressive/Qwen/Qwen3.5.md
@@ -19,7 +19,7 @@ Qwen3.5 features a Gated Delta Networks combined with sparse Mixture-of-Experts 
 
 | Model | BF16 (Full precision) | FP8 (8-bit Quantized) | FP4 (4-bit Quantized) |
 |-------|------|-----|-----|
-| Qwen3.5-397B-A17B | [Qwen/Qwen3.5-397B-A17B](https://huggingface.co/Qwen/Qwen3.5-397B-A17B) | [Qwen/Qwen3.5-397B-A17B-FP8](https://huggingface.co/Qwen/Qwen3.5-397B-A17B-FP8) | [nvidia/Qwen3.5-397B-A17B-NVFP4](https://huggingface.co/nvidia/Qwen3.5-397B-A17B-NVFP4) |
+| Qwen3.5-397B-A17B | [Qwen/Qwen3.5-397B-A17B](https://huggingface.co/Qwen/Qwen3.5-397B-A17B) | [Qwen/Qwen3.5-397B-A17B-FP8](https://huggingface.co/Qwen/Qwen3.5-397B-A17B-FP8) | [nvidia/Qwen3.5-397B-A17B-NVFP4](https://huggingface.co/nvidia/Qwen3.5-397B-A17B-NVFP4) (NVIDIA)<br/>[amd/Qwen3.5-397B-A17B-MXFP4](https://huggingface.co/amd/Qwen3.5-397B-A17B-MXFP4) (AMD) |
 | Qwen3.5-122B-A10B | [Qwen/Qwen3.5-122B-A10B](https://huggingface.co/Qwen/Qwen3.5-122B-A10B) | [Qwen/Qwen3.5-122B-A10B-FP8](https://huggingface.co/Qwen/Qwen3.5-122B-A10B-FP8) | - |
 | Qwen3.5-35B-A3B | [Qwen/Qwen3.5-35B-A3B](https://huggingface.co/Qwen/Qwen3.5-35B-A3B) | [Qwen/Qwen3.5-35B-A3B-FP8](https://huggingface.co/Qwen/Qwen3.5-35B-A3B-FP8) | - |
 | Qwen3.5-27B | [Qwen/Qwen3.5-27B](https://huggingface.co/Qwen/Qwen3.5-27B) | [Qwen/Qwen3.5-27B-FP8](https://huggingface.co/Qwen/Qwen3.5-27B-FP8) | - |
@@ -92,9 +92,10 @@ import Qwen35ConfigGenerator from '@site/src/components/autoregressive/Qwen35Con
         - **MI300X (192GB)** runs with tp=4.
         - **MI325X (256GB)** runs with tp=2.
         - **MI355X (288GB)** runs with tp=2.
-    - **FP4**: The FP4 quantized model requires ~250GB for weights, cutting memory by almost 4x. Only compatible with B200/B300 (Blackwell architecture).
+    - **FP4**: The FP4 quantized model requires ~250GB for weights, cutting memory by almost 4x. Compatible with B200/B300 (Blackwell architecture) and AMD MI355X.
         - **B200 (183GB)** runs with tp=4.
         - **B300 (275GB)** runs with tp=2.
+        - **MI355X (288GB)** runs with tp=2.
 
 | Hardware | Memory | BF16 TP | FP8 TP | FP4 TP |
 | -------- | ------ | ------- | ------ | --------------- |
@@ -104,7 +105,7 @@ import Qwen35ConfigGenerator from '@site/src/components/autoregressive/Qwen35Con
 | B300     | 275GB  | 4       | 2      | 2               |
 | MI300X   | 192GB  | 8       | 4      | N/A             |
 | MI325X   | 256GB  | 4       | 2      | N/A             |
-| MI355X   | 288GB  | 4       | 2      | N/A             |
+| MI355X   | 288GB  | 4       | 2      | 2               |
 
 :::caution FP8 KV Cache
 `--kv-cache-dtype fp8_e4m3` quantizes the KV cache to FP8 at runtime. Since these FP8 model checkpoints do not include pre-calibrated KV cache scaling factors, SGLang defaults to a scale of 1.0, which may cause noticeable accuracy degradation on reasoning-heavy tasks. It is not included in the generated commands above; add it manually only if memory constraints require the trade-off.
@@ -141,12 +142,16 @@ sglang serve \
   --tp 8 \
   --reasoning-parser qwen3 \
   --tool-call-parser qwen3_coder \
+  --trust-remote-code \
+  --attention-backend aiter \
   --mem-fraction-static 0.8 \
-  --attention-backend triton \
+  --model-loader-extra-config '{"enable_multithread_load": true}' \
+  --watchdog-timeout 1200 \
+  --disable-radix-cache \
   --host 0.0.0.0 \
   --port 30000
 ```
-> **Note:** TP8 works on all MI GPUs. For MI325X/MI355X, you can use --tp 4 as the minimum requirement.
+> **Note:** TP8 works on all MI GPUs. For MI325X/MI355X, you can use --tp 4 as the minimum requirement. MI355X also supports FP4 quantization with tp=2 using the model `amd/Qwen3.5-397B-A17B-MXFP4`.
 
 ### 4.1 Basic Usage
 

--- a/docs/autoregressive/Qwen/Qwen3.5.md
+++ b/docs/autoregressive/Qwen/Qwen3.5.md
@@ -151,7 +151,7 @@ sglang serve \
   --host 0.0.0.0 \
   --port 30000
 ```
-> **Note:** TP8 works on all MI GPUs. For MI325X/MI355X, you can use --tp 4 as the minimum requirement. MI355X also supports FP4 quantization with tp=2 using the model `amd/Qwen3.5-397B-A17B-MXFP4`.
+> **Note:** TP8 works on all MI GPUs. Minimum TP for MI325X/MI355X: BF16 uses --tp 4, FP8 uses --tp 2. MI355X also supports FP4 with --tp 2 using `amd/Qwen3.5-397B-A17B-MXFP4`.
 
 ### 4.1 Basic Usage
 

--- a/docs/autoregressive/Qwen/Qwen3.5.md
+++ b/docs/autoregressive/Qwen/Qwen3.5.md
@@ -42,10 +42,10 @@ uv pip install 'git+https://github.com/sgl-project/sglang.git#subdirectory=pytho
 docker pull lmsysorg/sglang:nightly-dev-20260216-d3bae71e
 
 # Or use Docker (AMD MI300X/MI325X)
-docker pull lmsysorg/sglang:v0.5.9-rocm720-mi30x
+docker pull lmsysorg/sglang:v0.5.10-rocm720-mi30x
 
 # Or use Docker (AMD MI355X)
-docker pull lmsysorg/sglang:v0.5.9-rocm720-mi35x
+docker pull lmsysorg/sglang:v0.5.10-rocm720-mi35x
 ```
 
 For the full Docker setup and other installation methods, please refer to the [official SGLang installation guide](https://docs.sglang.ai/get_started/install.html).

--- a/src/components/autoregressive/Qwen35ConfigGenerator/index.js
+++ b/src/components/autoregressive/Qwen35ConfigGenerator/index.js
@@ -220,6 +220,7 @@ const Qwen35ConfigGenerator = () => {
 
     generateCommand: function (values) {
       const { model, hardware, quantization, speculative, mambaCache } = values;
+      const amdGpus = ['mi300x', 'mi325x', 'mi355x'];
 
       const hwConfig = this.modelConfigs[model]?.[hardware]?.[quantization];
       if (!hwConfig) {
@@ -232,7 +233,6 @@ const Qwen35ConfigGenerator = () => {
       let modelName;
       if (quantization === 'fp4') {
         // AMD GPUs use MXFP4 variant, NVIDIA uses NVFP4 variant
-        const amdGpus = ['mi300x', 'mi325x', 'mi355x'];
         if (amdGpus.includes(hardware)) {
           modelName = 'amd/Qwen3.5-397B-A17B-MXFP4';
         } else {
@@ -258,7 +258,6 @@ const Qwen35ConfigGenerator = () => {
       }
 
       // Force Mamba V1 for AMD GPUs (V2 requires FLA backend)
-      const amdGpus = ['mi300x', 'mi325x', 'mi355x'];
       const actualMambaCache = amdGpus.includes(hardware) ? 'v1' : mambaCache;
       const adjustedValues = { ...values, mambaCache: actualMambaCache };
 
@@ -282,8 +281,8 @@ const Qwen35ConfigGenerator = () => {
         cmd += ` \\\n  --tokenizer-worker-num 6`;
       }
 
-      // Enable allreduce fusion for all Qwen3.5 configs (skip for FP4: benchmark only enables this for TP≥8).
-      if (quantization !== 'fp4') {
+      // Enable allreduce fusion for NVIDIA GPUs only (skip for FP4: benchmark only enables this for TP≥8, skip for AMD: not supported).
+      if (quantization !== 'fp4' && !amdGpus.includes(hardware)) {
         cmd += ` \\\n  --enable-flashinfer-allreduce-fusion`;
       }
 

--- a/src/components/autoregressive/Qwen35ConfigGenerator/index.js
+++ b/src/components/autoregressive/Qwen35ConfigGenerator/index.js
@@ -22,7 +22,7 @@ import ConfigGenerator from '../../base/ConfigGenerator';
  *   35B-A3B:   H100 tp=1, H200 tp=1, B200 tp=1, B300 tp=1, MI300X tp=1, MI325X tp=1, MI355X tp=1
  *   27B:       tp=1 on all hardware (including MI300X, MI325X, MI355X)
  *
- * FP4 (397B only, Blackwell required): B200 tp=4, B300 tp=2
+ * FP4 (397B only): B200 tp=4, B300 tp=2, MI355X tp=2
  */
 
 const MOE_MODELS = new Set(['397b', '122b', '35b']);
@@ -71,7 +71,7 @@ const Qwen35ConfigGenerator = () => {
             { id: 'b300', label: 'B300', default: isNvfp4, disabled: false },
             { id: 'mi300x', label: 'MI300X', default: false, disabled: isNvfp4 },
             { id: 'mi325x', label: 'MI325X', default: false, disabled: isNvfp4 },
-            { id: 'mi355x', label: 'MI355X', default: false, disabled: isNvfp4 }
+            { id: 'mi355x', label: 'MI355X', default: false, disabled: false }
           ];
         }
       },
@@ -151,7 +151,7 @@ const Qwen35ConfigGenerator = () => {
         b300: { bf16: { tp: 4,  mem: 0.8 }, fp8: { tp: 2, mem: 0.8 }, fp4: { tp: 2, mem: 0.8 } },
         mi300x: { bf16: { tp: 8, mem: 0.8 }, fp8: { tp: 4, mem: 0.8 } },
         mi325x: { bf16: { tp: 4, mem: 0.8 }, fp8: { tp: 2, mem: 0.8 } },
-        mi355x: { bf16: { tp: 4, mem: 0.8 }, fp8: { tp: 2, mem: 0.8 } }
+        mi355x: { bf16: { tp: 4, mem: 0.8 }, fp8: { tp: 2, mem: 0.8 }, fp4: { tp: 2, mem: 0.8 } }
       },
       '122b': {
         h100: { bf16: { tp: 4, mem: 0.8 }, fp8: { tp: 2, mem: 0.8 } },
@@ -231,7 +231,13 @@ const Qwen35ConfigGenerator = () => {
 
       let modelName;
       if (quantization === 'fp4') {
-        modelName = 'nvidia/Qwen3.5-397B-A17B-NVFP4';
+        // AMD GPUs use MXFP4 variant, NVIDIA uses NVFP4 variant
+        const amdGpus = ['mi300x', 'mi325x', 'mi355x'];
+        if (amdGpus.includes(hardware)) {
+          modelName = 'amd/Qwen3.5-397B-A17B-MXFP4';
+        } else {
+          modelName = 'nvidia/Qwen3.5-397B-A17B-NVFP4';
+        }
       } else {
         const suffix = MODEL_SUFFIX[model];
         const quantSuffix = quantization === 'fp8' ? '-FP8' : '';
@@ -296,7 +302,11 @@ const Qwen35ConfigGenerator = () => {
 
       // Append AMD GPU-specific backend configurations
       if (hardware === 'mi300x' || hardware === 'mi325x' || hardware === 'mi355x') {
-        cmd += ` \\\n  --attention-backend triton`;
+        cmd += ` \\\n  --trust-remote-code`;
+        cmd += ` \\\n  --attention-backend aiter`;
+        cmd += ` \\\n  --model-loader-extra-config '{"enable_multithread_load": true}'`;
+        cmd += ` \\\n  --watchdog-timeout 1200`;
+        cmd += ` \\\n  --disable-radix-cache`;
       }
 
       // Tokenizer workers for H200 and B200/B300

--- a/src/components/autoregressive/Qwen35ConfigGenerator/index.js
+++ b/src/components/autoregressive/Qwen35ConfigGenerator/index.js
@@ -224,7 +224,7 @@ const Qwen35ConfigGenerator = () => {
       const hwConfig = this.modelConfigs[model]?.[hardware]?.[quantization];
       if (!hwConfig) {
         if (quantization === 'fp4') {
-          return '# FP4 requires B200/B300 (Blackwell) and is only available for Qwen3.5-397B-A17B';
+          return '# FP4 requires B200/B300 (Blackwell) or MI355X (AMD) and is only available for Qwen3.5-397B-A17B';
         }
         return '# Please select a valid hardware and quantization combination';
       }
@@ -316,8 +316,8 @@ const Qwen35ConfigGenerator = () => {
         }
       }
 
-      // FP4-specific backend settings
-      if (quantization === 'fp4') {
+      // FP4-specific backend settings (NVIDIA only)
+      if (quantization === 'fp4' && (hardware === 'b200' || hardware === 'b300')) {
         cmd += ' \\\n  --quantization modelopt_fp4';
         cmd += ' \\\n  --fp4-gemm-backend flashinfer_cutlass';
         cmd += ' \\\n  --kv-cache-dtype fp8_e4m3';

--- a/src/components/autoregressive/Qwen35ConfigGenerator/index.js
+++ b/src/components/autoregressive/Qwen35ConfigGenerator/index.js
@@ -22,7 +22,7 @@ import ConfigGenerator from '../../base/ConfigGenerator';
  *   35B-A3B:   H100 tp=1, H200 tp=1, B200 tp=1, B300 tp=1, MI300X tp=1, MI325X tp=1, MI355X tp=1
  *   27B:       tp=1 on all hardware (including MI300X, MI325X, MI355X)
  *
- * FP4 (397B only): B200 tp=4, B300 tp=2, MI355X tp=2
+ * FP4 (397B only): B200 tp=4, B300 tp=2 (Blackwell/NVIDIA), MI355X tp=2 (AMD)
  */
 
 const MOE_MODELS = new Set(['397b', '122b', '35b']);
@@ -124,6 +124,15 @@ const Qwen35ConfigGenerator = () => {
         getDynamicItems: (currentValues) => {
           const amdGpus = ['mi300x', 'mi325x', 'mi355x'];
           const isAmdGpu = amdGpus.includes(currentValues.hardware);
+          const mtpEnabled = currentValues.speculative === 'enabled';
+
+          // MTP requires V2 mamba radix cache
+          if (mtpEnabled && !isAmdGpu) {
+            return [
+              { id: 'v1', label: 'V1', default: false, disabled: true },
+              { id: 'v2', label: 'V2', default: true }
+            ];
+          }
 
           // Show V2 as disabled for AMD GPUs (V2 requires FLA backend, NVIDIA only)
           if (isAmdGpu) {
@@ -139,7 +148,7 @@ const Qwen35ConfigGenerator = () => {
             { id: 'v2', label: 'V2', default: false }
           ];
         },
-        commandRule: (value) => value === 'v2' ? '--mamba-scheduler-strategy extra_buffer \\\n  --page-size 64' : null
+        commandRule: (value) => value === 'v2' ? '--mamba-scheduler-strategy extra_buffer' : null
       }
     },
 
@@ -220,7 +229,6 @@ const Qwen35ConfigGenerator = () => {
 
     generateCommand: function (values) {
       const { model, hardware, quantization, speculative, mambaCache } = values;
-      const amdGpus = ['mi300x', 'mi325x', 'mi355x'];
 
       const hwConfig = this.modelConfigs[model]?.[hardware]?.[quantization];
       if (!hwConfig) {
@@ -230,10 +238,13 @@ const Qwen35ConfigGenerator = () => {
         return '# Please select a valid hardware and quantization combination';
       }
 
+      const amdGpus = ['mi300x', 'mi325x', 'mi355x'];
+      const isAmdGpu = amdGpus.includes(hardware);
+
       let modelName;
       if (quantization === 'fp4') {
         // AMD GPUs use MXFP4 variant, NVIDIA uses NVFP4 variant
-        if (amdGpus.includes(hardware)) {
+        if (isAmdGpu) {
           modelName = 'amd/Qwen3.5-397B-A17B-MXFP4';
         } else {
           modelName = 'nvidia/Qwen3.5-397B-A17B-NVFP4';
@@ -258,7 +269,8 @@ const Qwen35ConfigGenerator = () => {
       }
 
       // Force Mamba V1 for AMD GPUs (V2 requires FLA backend)
-      const actualMambaCache = amdGpus.includes(hardware) ? 'v1' : mambaCache;
+      // Force Mamba V2 when MTP is enabled
+      const actualMambaCache = isAmdGpu ? 'v1' : (speculative === 'enabled' ? 'v2' : mambaCache);
       const adjustedValues = { ...values, mambaCache: actualMambaCache };
 
       // Apply commandRule from all options except quantization (handled via model name)
@@ -282,7 +294,7 @@ const Qwen35ConfigGenerator = () => {
       }
 
       // Enable allreduce fusion for NVIDIA GPUs only (skip for FP4: benchmark only enables this for TP≥8, skip for AMD: not supported).
-      if (quantization !== 'fp4' && !amdGpus.includes(hardware)) {
+      if (quantization !== 'fp4' && !isAmdGpu) {
         cmd += ` \\\n  --enable-flashinfer-allreduce-fusion`;
       }
 
@@ -300,7 +312,7 @@ const Qwen35ConfigGenerator = () => {
       }
 
       // Append AMD GPU-specific backend configurations
-      if (hardware === 'mi300x' || hardware === 'mi325x' || hardware === 'mi355x') {
+      if (isAmdGpu) {
         cmd += ` \\\n  --trust-remote-code`;
         cmd += ` \\\n  --attention-backend aiter`;
         cmd += ` \\\n  --model-loader-extra-config '{"enable_multithread_load": true}'`;


### PR DESCRIPTION
## Summary

Adds support for AMD's MXFP4 quantization for Qwen3.5-397B-A17B on MI355X GPUs.

**Key additions:**
- New model variant: `amd/Qwen3.5-397B-A17B-MXFP4`
- MI355X hardware support for FP4 with TP=2 as minimum requirement. 
- AMD-specific optimizations (AITER backend, multi-threaded loading, disabled radix cache)
- Interactive config generator now supports MI355X + FP4 selection
- Updated documentation with hardware requirements and deployment examples

## Files Modified

- `docs/autoregressive/Qwen/Qwen3.5.md`
- `src/components/autoregressive/Qwen35ConfigGenerator/index.js`
- `data/models/src/v0.5.10/qwen35.yaml`
- `data/models/generated/v0.5.10/qwen35.yaml`
