### PR TITLE
Add MMMU Pro Vision benchmark for Kimi-K2.6

### DIFF
--- a/docs/autoregressive/Moonshotai/Kimi-K2.6.md
+++ b/docs/autoregressive/Moonshotai/Kimi-K2.6.md
@@ -577,9 +577,30 @@ python3 eval.py ocrbench \
 
 #### 5.1.5 MMMU Pro Vision
 
-```text
-Pending update...
+- Dataset: [MMMU Pro](https://huggingface.co/datasets/MMMU/MMMU_Pro) standard 10-option subset (1,730 questions with images)
+- Evaluation Tool: [Kimi-Vendor-Verifier](https://github.com/MoonshotAI/Kimi-Vendor-Verifier) (inspect-ai based)
+- Settings: max_tokens=32,768, thinking mode (default), max_connections=256
+
+> **Important**: Kimi-K2.6 is a reasoning model. Setting `max_tokens` too low (e.g., 4096) causes the thinking process to consume the entire token budget, leaving no tokens for the final answer. Use `max_tokens=32768` or higher.
+
+**Evaluation Command:**
+
+```bash
+cd Kimi-Vendor-Verifier
+
+OPENAI_BASE_URL=http://localhost:30000/v1 OPENAI_API_KEY=placeholder \
+python3 eval.py mmmu \
+  --model openai/moonshotai/Kimi-K2.6 \
+  --max-tokens 32768 \
+  --think-mode none \
+  --max-connections 256
 ```
+
+**Results (1,481/1,730 samples completed):**
+
+| Evaluation Mode | Accuracy |
+|-----------------|----------|
+| pass@1 | **82.2%** |
 
 ### 5.2 Speed Benchmark
 


### PR DESCRIPTION
## Summary
- Add MMMU Pro Vision (10-choice) benchmark result for Kimi-K2.6: **82.2%** accuracy (1,481/1,730 samples)
- Include evaluation command, dataset info, and important note about `max_tokens` requirement for reasoning models

## Key Finding
Reasoning models like Kimi-K2.6 need `max_tokens≥32768` for MMMU Pro evaluation. With `max_tokens=4096`, the thinking process consumes the entire token budget, leaving the `content` field empty — causing the answer parser to randomly guess (resulting in ~45% accuracy for 10-choice). With `max_tokens=32768`, the model properly outputs answers and achieves 82.2%.

## Test Environment
- Hardware: 8× NVIDIA H200
- Model: moonshotai/Kimi-K2.6 (INT4), TP=8
- SGLang version: 0.5.9
- Evaluation tool: Kimi-Vendor-Verifier (inspect-ai based)