### PR TITLE
feat(kimi-k26): add B200, GB200, GB300 NVIDIA hardware platform support

### DIFF
--- a/data/models/generated/v0.5.10/kimi-k26.yaml
+++ b/data/models/generated/v0.5.10/kimi-k26.yaml
@@ -125,7 +125,7 @@ families:
           engine:
             env_vars: {}
             tp: 4
-            dp: null
+            dp: 4
             ep: null
             enable_dp_attention: null
             extra_args:
@@ -159,7 +159,7 @@ families:
           engine:
             env_vars: {}
             tp: 4
-            dp: null
+            dp: 4
             ep: null
             enable_dp_attention: null
             extra_args:

--- a/data/models/generated/v0.5.10/kimi-k26.yaml
+++ b/data/models/generated/v0.5.10/kimi-k26.yaml
@@ -46,6 +46,40 @@ families:
             - --trust-remote-code
           prefill: null
           decode: null
+      B200:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: int4
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --trust-remote-code
+          prefill: null
+          decode: null
+        - name: high-throughput-dp
+          attributes:
+            nodes: single
+            optimization: high-throughput
+            quantization: int4
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: 8
+            ep: null
+            enable_dp_attention: true
+            extra_args:
+            - --trust-remote-code
+          prefill: null
+          decode: null
       B300:
         configurations:
         - name: default
@@ -74,6 +108,74 @@ families:
             env_vars: {}
             tp: 8
             dp: 8
+            ep: null
+            enable_dp_attention: true
+            extra_args:
+            - --trust-remote-code
+          prefill: null
+          decode: null
+      GB200:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: int4
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 4
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --trust-remote-code
+          prefill: null
+          decode: null
+        - name: high-throughput-dp
+          attributes:
+            nodes: single
+            optimization: high-throughput
+            quantization: int4
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 4
+            dp: 4
+            ep: null
+            enable_dp_attention: true
+            extra_args:
+            - --trust-remote-code
+          prefill: null
+          decode: null
+      GB300:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: int4
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 4
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --trust-remote-code
+          prefill: null
+          decode: null
+        - name: high-throughput-dp
+          attributes:
+            nodes: single
+            optimization: high-throughput
+            quantization: int4
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 4
+            dp: 4
             ep: null
             enable_dp_attention: true
             extra_args:

--- a/data/models/src/v0.5.10/kimi-k26.yaml
+++ b/data/models/src/v0.5.10/kimi-k26.yaml
@@ -5,8 +5,11 @@ vendor: moonshotai
 
 defaults:
   hardware:
-    H200: { tp: 8 }
-    B300: { tp: 8 }
+    H200:  { tp: 8 }
+    B200:  { tp: 8 }
+    B300:  { tp: 8 }
+    GB200: { tp: 4, dp: 4 }
+    GB300: { tp: 4, dp: 4 }
     MI300X: { tp: 4, extra_args: ["--mem-fraction-static", "0.8", "--kv-cache-dtype", "fp8_e4m3"] }
     MI325X: { tp: 4, extra_args: ["--mem-fraction-static", "0.8", "--kv-cache-dtype", "fp8_e4m3"] }
     MI350X: { tp: 4, extra_args: ["--mem-fraction-static", "0.8", "--kv-cache-dtype", "fp8_e4m3"] }

--- a/docs/autoregressive/Moonshotai/Kimi-K2.6.md
+++ b/docs/autoregressive/Moonshotai/Kimi-K2.6.md
@@ -49,7 +49,7 @@ import KimiK26ConfigGenerator from '@site/src/components/autoregressive/KimiK26C
 
 ### 3.2 Configuration Tips
 
-- **Memory**: Requires GPUs with ≥140GB each. Supported platforms: H200 (8×, TP=8), B300 (8×, TP=8), MI300X/MI325X (4×, TP=4), MI350X/MI355X (4×, TP=4). Use `--context-length 128000` to conserve memory.
+- **Memory**: Requires GPUs with ≥140GB each. Supported platforms: H200 (8×, TP=8), B200 (8×, TP=8), B300 (8×, TP=8), GB200 (TP=4, DP=4), GB300 (TP=4, DP=4), MI300X/MI325X (4×, TP=4), MI350X/MI355X (4×, TP=4). Use `--context-length 128000` to conserve memory.
 - **AMD GPU TP Constraint**: On AMD GPUs, TP must be ≤ 4 (not 8). Kimi-K2.6 has 64 attention heads; the AITER MLA kernel requires `heads_per_gpu % 16 == 0`. With TP=4, each GPU gets 16 heads (valid). With TP=8, each GPU gets 8 heads (invalid).
 - **AMD Docker Image**: Use `lmsysorg/sglang:v0.5.9-rocm700-mi35x` for MI350X/MI355X and `lmsysorg/sglang:v0.5.9-rocm700-mi30x` for MI300X/MI325X.
 - **DP Attention**: Enable with `--dp <N> --enable-dp-attention` for production throughput. A common choice is to set `--dp` equal to `--tp`, but this is not required.

--- a/src/components/autoregressive/KimiK26ConfigGenerator/index.js
+++ b/src/components/autoregressive/KimiK26ConfigGenerator/index.js
@@ -6,8 +6,11 @@ import ConfigGenerator from '../../base/ConfigGenerator';
  * Supports Kimi-K2.6 native multimodal agentic model with reasoning and tool calling.
  *
  * GPU requirements:
- *   H200: tp=8
- *   B300: tp=8
+ *   H200:  tp=8
+ *   B200:  tp=8
+ *   B300:  tp=8
+ *   GB200: tp=4, dp=4
+ *   GB300: tp=4, dp=4
  *   MI300X: tp=4 (64 heads / 4 = 16 heads per GPU, AITER MLA requires heads_per_gpu % 16 == 0)
  *   MI325X: tp=4 (same constraint as MI300X)
  *   MI350X: tp=4 (same constraint as MI300X)
@@ -23,7 +26,10 @@ const KimiK26ConfigGenerator = () => {
         title: 'Hardware Platform',
         items: [
           { id: 'h200', label: 'H200', default: true },
+          { id: 'b200', label: 'B200', default: false },
           { id: 'b300', label: 'B300', default: false },
+          { id: 'gb200', label: 'GB200', default: false },
+          { id: 'gb300', label: 'GB300', default: false },
           { id: 'mi300x', label: 'MI300X', default: false },
           { id: 'mi325x', label: 'MI325X', default: false },
           { id: 'mi350x', label: 'MI350X', default: false },
@@ -60,8 +66,11 @@ const KimiK26ConfigGenerator = () => {
     },
 
     modelConfigs: {
-      h200: { tp: 8 },
-      b300: { tp: 8 },
+      h200:  { tp: 8 },
+      b200:  { tp: 8 },
+      b300:  { tp: 8 },
+      gb200: { tp: 4, dp: 4 },
+      gb300: { tp: 4, dp: 4 },
       mi300x: { tp: 4 },
       mi325x: { tp: 4 },
       mi350x: { tp: 4 },
@@ -75,6 +84,7 @@ const KimiK26ConfigGenerator = () => {
       const modelName = `${this.modelFamily}/Kimi-K2.6`;
       const hwConfig = this.modelConfigs[hardware];
       const tpValue = hwConfig.tp;
+      const dpValue = hwConfig.dp ?? tpValue;
 
       let cmd = '';
 
@@ -91,9 +101,9 @@ const KimiK26ConfigGenerator = () => {
       }
       cmd += ' \\\n  --trust-remote-code';
 
-      // DP Attention: --dp matches --tp
+      // DP Attention: GB200/GB300 use fixed dp=4; others use --dp matching --tp
       if (values.dpattention === 'enabled') {
-        cmd += ` \\\n  --dp ${tpValue} \\\n  --enable-dp-attention`;
+        cmd += ` \\\n  --dp ${dpValue} \\\n  --enable-dp-attention`;
       }
 
       // Apply commandRule from all options


### PR DESCRIPTION
## Summary

- **B200**: TP=8 (same configuration as H200/B300)
- **GB200**: TP=4
- **GB300**: TP=4

## Changes

- `src/components/autoregressive/KimiK26ConfigGenerator/index.js`: Added B200, GB200, GB300 to the interactive command generator hardware selector; GB200/GB300 carry a `--tp 4`
- `docs/autoregressive/Moonshotai/Kimi-K2.6.md`: Updated Section 3.2 Configuration Tips to list all newly supported platforms
- `data/models/src/v0.5.10/kimi-k26.yaml`: Added B200, GB200, GB300 hardware entries
- `data/models/generated/v0.5.10/kimi-k26.yaml`: Added corresponding generated hardware blocks (both `default` and `high-throughput-dp` configurations)

## Test plan

- [ ] Verify interactive config generator renders B200, GB200, GB300 options
- [ ] Confirm GB200/GB300 with `--tp 4`
- [ ] Confirm B200 produces `--tp 8` (matching H200/B300)
- [ ] Run `npm run build` to validate Docusaurus build

🤖 Generated with [Claude Code](https://claude.com/claude-code)