### PR TITLE
feat(glm51): add B300 and GB200 NVIDIA hardware platform support

### DIFF
--- a/data/models/generated/v0.5.10/glm51.yaml
+++ b/data/models/generated/v0.5.10/glm51.yaml
@@ -177,6 +177,61 @@ families:
             - '4'
           prefill: null
           decode: null
+      B300:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: bf16
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 16
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args: []
+          prefill: null
+          decode: null
+        - name: high-throughput-dp
+          attributes:
+            nodes: single
+            optimization: high-throughput
+            quantization: bf16
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 16
+            dp: 8
+            ep: null
+            enable_dp_attention: true
+            extra_args: []
+          prefill: null
+          decode: null
+        - name: speculative-mtp
+          attributes:
+            nodes: single
+            optimization: low-latency
+            quantization: bf16
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 16
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --speculative-algorithm
+            - EAGLE
+            - --speculative-num-steps
+            - '3'
+            - --speculative-eagle-topk
+            - '1'
+            - --speculative-num-draft-tokens
+            - '4'
+          prefill: null
+          decode: null
   - name: GLM-5.1-FP8
     model_path: zai-org/GLM-5.1-FP8
     attributes:
@@ -186,6 +241,61 @@ families:
         reasoning_parser: glm45
         chat_template: null
     hardware:
+      GB200:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: fp8
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 4
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args: []
+          prefill: null
+          decode: null
+        - name: high-throughput-dp
+          attributes:
+            nodes: single
+            optimization: high-throughput
+            quantization: fp8
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 4
+            dp: 4
+            ep: null
+            enable_dp_attention: true
+            extra_args: []
+          prefill: null
+          decode: null
+        - name: speculative-mtp
+          attributes:
+            nodes: single
+            optimization: low-latency
+            quantization: fp8
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 4
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --speculative-algorithm
+            - EAGLE
+            - --speculative-num-steps
+            - '3'
+            - --speculative-eagle-topk
+            - '1'
+            - --speculative-num-draft-tokens
+            - '4'
+          prefill: null
+          decode: null
       GB300:
         configurations:
         - name: default

--- a/data/models/src/v0.5.10/glm51.yaml
+++ b/data/models/src/v0.5.10/glm51.yaml
@@ -2,18 +2,22 @@
 # This file is compiled to data/models/generated/glm51.yaml
 #
 # GPU requirements (BF16 needs 2x GPUs compared to FP8):
-#   H100: FP8 tp=16, BF16 tp=32
-#   H200: FP8 tp=8, BF16 tp=16
-#   B200: FP8 tp=8, BF16 tp=16
+#   H100:  FP8 tp=16, BF16 tp=32
+#   H200:  FP8 tp=8,  BF16 tp=16
+#   B200:  FP8 tp=8,  BF16 tp=16
+#   B300:  FP8 tp=8,  BF16 tp=16
+#   GB200: FP8 tp=4
 #   GB300: FP8 tp=4
 
 vendor: zai-org
 
 defaults:
   hardware:
-    H100: { tp: 16 }
-    H200: { tp: 8 }
-    B200: { tp: 8 }
+    H100:  { tp: 16 }
+    H200:  { tp: 8 }
+    B200:  { tp: 8 }
+    B300:  { tp: 8 }
+    GB200: { tp: 4 }
     GB300: { tp: 4 }
   configurations:
     - name: default
@@ -53,11 +57,35 @@ families:
           H100: { tp: 32 }
           H200: { tp: 16 }
           B200: { tp: 16 }
+          B300: { tp: 16 }
 
       # GLM-5.1 FP8
       - name: GLM-5.1-FP8
         quantization: fp8
         hardware:
+          GB200:
+            tp: 4
+            configurations:
+              - name: default
+                nodes: single
+                optimization: balanced
+              - name: high-throughput-dp
+                nodes: single
+                optimization: high-throughput
+                dp: 4
+                enable_dp_attention: true
+              - name: speculative-mtp
+                nodes: single
+                optimization: low-latency
+                extra_args:
+                  - --speculative-algorithm
+                  - EAGLE
+                  - --speculative-num-steps
+                  - "3"
+                  - --speculative-eagle-topk
+                  - "1"
+                  - --speculative-num-draft-tokens
+                  - "4"
           GB300:
             tp: 4
             configurations:

--- a/docs/autoregressive/GLM/GLM-5.1.md
+++ b/docs/autoregressive/GLM/GLM-5.1.md
@@ -19,7 +19,7 @@ This section provides deployment configurations optimized for different hardware
 
 ### 3.1 Basic Configuration
 
-**Interactive Command Generator**: Use the configuration selector below to automatically generate the appropriate deployment command for your hardware platform, quantization method, and capabilities. SGLang supports serving GLM-5.1 on NVIDIA H100, H200, B200, GB300, and AMD MI300X/MI325X/MI355X GPUs.
+**Interactive Command Generator**: Use the configuration selector below to automatically generate the appropriate deployment command for your hardware platform, quantization method, and capabilities. SGLang supports serving GLM-5.1 on NVIDIA H100, H200, B200, B300, GB200, GB300, and AMD MI300X/MI325X/MI355X GPUs.
 
 import GLM51ConfigGenerator from '@site/src/components/autoregressive/GLM51ConfigGenerator';
 
@@ -38,12 +38,14 @@ import GLM51ConfigGenerator from '@site/src/components/autoregressive/GLM51Confi
 | H100     | tp=16 | tp=32 |
 | H200     | tp=8  | tp=16 |
 | B200     | tp=8  | tp=16 |
+| B300     | tp=8  | tp=16 |
+| GB200    | tp=4  | —     |
 | GB300    | tp=4  | —     |
 | MI300X/MI325X | tp=8 | tp=8 |
 | MI355X   | tp=8 | tp=8 |
 
 - **AMD GPUs**: Both BF16 and FP8 checkpoints are supported on MI300X/MI325X/MI355X at tp=8. Use `--nsa-prefill-backend tilelang --nsa-decode-backend tilelang` for the NSA attention backend. Add `--chunked-prefill-size 131072` and `--watchdog-timeout 1200` (20 minutes for weight loading). FP8 uses approximately half the memory of BF16 (~89 GB/GPU vs ~175 GB/GPU). EAGLE speculative decoding is not currently supported on AMD for GLM-5.1.
-- **GB300**: Only the FP8 checkpoint is recommended on GB300, with `tp=4`. For high-throughput DP attention on GB300, use `--dp 4`.
+- **GB200/GB300**: Only the FP8 checkpoint is recommended on GB200/GB300, with `tp=4`. For high-throughput DP attention on GB200/GB300, use `--dp 4`.
 - For other configuration tips, please refer to [DeepSeek V3.2 documentation](https://docs.sglang.io/basic_usage/deepseek_v32.html). GLM-5.1 and DeepSeek V3.2 share the same model structure, so the optimization techniques between these two models are also common (MTP, DSA kernel, Context Parallel...).
 - Use `--json-model-override-args '{"index_topk_pattern": "FFSFSSSFSSFFFSSSFFFSFSSSSSSFFSFFSFFSSFFFFFFSFFFFFSFFSSSSSSFSFFFSFSSSFSFFSFFSSS"}'` for GLM-5.1-FP8 if you want to enable the [IndexCache](https://github.com/THUDM/IndexCache) method. This feature is supported through [this PR](https://github.com/sgl-project/sglang/pull/21405) and introduces only a small accuracy loss. However, if you are running rigorous accuracy evaluations, it is not recommended to enable this feature.
 

--- a/src/components/autoregressive/GLM51ConfigGenerator/index.js
+++ b/src/components/autoregressive/GLM51ConfigGenerator/index.js
@@ -7,9 +7,11 @@ import ConfigGenerator from '../../base/ConfigGenerator';
  * with BF16/FP8 quantization, reasoning parser, DP attention, and speculative decoding
  *
  * GPU requirements (BF16 needs 2x GPUs compared to FP8):
- *   H100: FP8 tp=16, BF16 tp=32
- *   H200: FP8 tp=8, BF16 tp=16
- *   B200: FP8 tp=8, BF16 tp=16
+ *   H100:  FP8 tp=16, BF16 tp=32
+ *   H200:  FP8 tp=8,  BF16 tp=16
+ *   B200:  FP8 tp=8,  BF16 tp=16
+ *   B300:  FP8 tp=8,  BF16 tp=16
+ *   GB200: FP8 tp=4
  *   GB300: FP8 tp=4
  *   MI300X/MI325X: BF16 tp=8
  *   MI355X: BF16 tp=8
@@ -25,6 +27,8 @@ const GLM51ConfigGenerator = () => {
         items: [
           { id: 'h200', label: 'H200', default: true },
           { id: 'b200', label: 'B200', default: false },
+          { id: 'b300', label: 'B300', default: false },
+          { id: 'gb200', label: 'GB200', default: false },
           { id: 'gb300', label: 'GB300', default: false },
           { id: 'h100', label: 'H100', default: false },
           { id: 'mi300x', label: 'MI300X/MI325X', default: false },
@@ -37,15 +41,15 @@ const GLM51ConfigGenerator = () => {
         getDynamicItems: (values) => {
           const hw = values.hardware;
           const isAMD = hw === 'mi300x' || hw === 'mi355x';
-          const isGB300 = hw === 'gb300';
+          const isGraceBW = hw === 'gb200' || hw === 'gb300';
           return [
             {
               id: 'bf16',
               label: 'BF16',
               subtitle: 'Full Weights',
               default: isAMD,
-              disabled: isGB300,
-              disabledReason: isGB300 ? 'BF16 is not recommended on GB300 for GLM-5.1' : ''
+              disabled: isGraceBW,
+              disabledReason: isGraceBW ? 'BF16 is not recommended on GB200/GB300 for GLM-5.1' : ''
             },
             { id: 'fp8', label: 'FP8', subtitle: 'High Throughput', default: !isAMD, disabled: isAMD, disabledReason: isAMD ? 'FP8 not verified on AMD' : '' }
           ];
@@ -93,10 +97,12 @@ const GLM51ConfigGenerator = () => {
     },
 
     modelConfigs: {
-      h100: { fp8: { tp: 16, mem: 0.85 }, bf16: { tp: 32, mem: 0.85 } },
-      h200: { fp8: { tp: 8, mem: 0.85 }, bf16: { tp: 16, mem: 0.85 } },
-      b200: { fp8: { tp: 8, mem: 0.9 }, bf16: { tp: 16, mem: 0.9 } },
-      gb300: { fp8: { tp: 4, mem: 0.9 } },
+      h100:  { fp8: { tp: 16, mem: 0.85 }, bf16: { tp: 32, mem: 0.85 } },
+      h200:  { fp8: { tp: 8,  mem: 0.85 }, bf16: { tp: 16, mem: 0.85 } },
+      b200:  { fp8: { tp: 8,  mem: 0.9  }, bf16: { tp: 16, mem: 0.9  } },
+      b300:  { fp8: { tp: 8,  mem: 0.9  }, bf16: { tp: 16, mem: 0.9  } },
+      gb200: { fp8: { tp: 4,  mem: 0.9  } },
+      gb300: { fp8: { tp: 4,  mem: 0.9  } },
       mi300x: { bf16: { tp: 8, mem: 0.8 } },
       mi355x: { bf16: { tp: 8, mem: 0.8 } }
     },
@@ -104,8 +110,8 @@ const GLM51ConfigGenerator = () => {
     generateCommand: function (values) {
       const { hardware, quantization } = values;
       const isAMD = hardware === 'mi300x' || hardware === 'mi355x';
-      const isGB300 = hardware === 'gb300';
-      const effectiveQuant = isAMD ? 'bf16' : (isGB300 && quantization === 'bf16' ? 'fp8' : quantization);
+      const isGraceBW = hardware === 'gb200' || hardware === 'gb300';
+      const effectiveQuant = isAMD ? 'bf16' : (isGraceBW && quantization === 'bf16' ? 'fp8' : quantization);
       const modelSuffix = effectiveQuant === 'fp8' ? '-FP8' : '';
       const modelName = `${this.modelFamily}/GLM-5.1${modelSuffix}`;
       const hwConfig = this.modelConfigs[hardware][effectiveQuant];


### PR DESCRIPTION
## Summary

- **B300**: FP8 tp=8 / BF16 tp=16 (mirrors B200 configuration)
- **GB200**: FP8 tp=4 only; dp=4 for high-throughput DP attention (mirrors GB300 — BF16 not recommended)

## Changes

- `src/components/autoregressive/GLM51ConfigGenerator/index.js`: Added B300 and GB200 to the hardware selector; unified `isGraceBW` flag covers both GB200 and GB300 for BF16-disabled and effective-quant logic; GB200 modelConfig mirrors GB300 (`fp8: { tp: 4, mem: 0.9 }`)
- `docs/autoregressive/GLM/GLM-5.1.md`: Added B300 and GB200 rows to the hardware table; updated GPU list in section 3.1; expanded GB300-specific note to cover GB200/GB300
- `data/models/src/v0.5.10/glm51.yaml`: Added B300 and GB200 to `defaults.hardware`; added B300 to BF16 model hardware overrides; added GB200 to FP8 model with custom `dp: 4` high-throughput configuration
- `data/models/generated/v0.5.10/glm51.yaml`: Added B300 hardware block to GLM-5.1 (BF16) and GB200 hardware block to GLM-5.1-FP8 (all three config presets)

## Test plan

- [ ] Verify interactive config generator renders B300 and GB200 options
- [ ] Confirm GB200 with BF16 is disabled (same as GB300)
- [ ] Confirm GB200 FP8 with DP Attention produces `--tp 4 --dp 4 --enable-dp-attention`
- [ ] Confirm B300 FP8 produces `--tp 8` and BF16 produces `--tp 16`
- [ ] Run `npm run build` to validate Docusaurus build

🤖 Generated with [Claude Code](https://claude.com/claude-code)