### PR TITLE
AMD GLM-5.1 FP8 & FP4 Support

### DIFF
--- a/data/models/generated/v0.5.10/glm51.yaml
+++ b/data/models/generated/v0.5.10/glm51.yaml
@@ -202,6 +202,60 @@ families:
             - '1200'
           prefill: null
           decode: null
+        - name: high-throughput-dp
+          attributes:
+            nodes: single
+            optimization: high-throughput
+            quantization: bf16
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: 8
+            ep: null
+            enable_dp_attention: true
+            extra_args:
+            - --nsa-prefill-backend
+            - tilelang
+            - --nsa-decode-backend
+            - tilelang
+            - --chunked-prefill-size
+            - '131072'
+            - --watchdog-timeout
+            - '1200'
+          prefill: null
+          decode: null
+        - name: speculative-mtp
+          attributes:
+            nodes: single
+            optimization: low-latency
+            quantization: bf16
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --nsa-prefill-backend
+            - tilelang
+            - --nsa-decode-backend
+            - tilelang
+            - --chunked-prefill-size
+            - '131072'
+            - --watchdog-timeout
+            - '1200'
+            - --speculative-algorithm
+            - EAGLE
+            - --speculative-num-steps
+            - '3'
+            - --speculative-eagle-topk
+            - '1'
+            - --speculative-num-draft-tokens
+            - '4'
+          prefill: null
+          decode: null
       MI325X:
         configurations:
         - name: default
@@ -227,6 +281,60 @@ families:
             - '1200'
           prefill: null
           decode: null
+        - name: high-throughput-dp
+          attributes:
+            nodes: single
+            optimization: high-throughput
+            quantization: bf16
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: 8
+            ep: null
+            enable_dp_attention: true
+            extra_args:
+            - --nsa-prefill-backend
+            - tilelang
+            - --nsa-decode-backend
+            - tilelang
+            - --chunked-prefill-size
+            - '131072'
+            - --watchdog-timeout
+            - '1200'
+          prefill: null
+          decode: null
+        - name: speculative-mtp
+          attributes:
+            nodes: single
+            optimization: low-latency
+            quantization: bf16
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --nsa-prefill-backend
+            - tilelang
+            - --nsa-decode-backend
+            - tilelang
+            - --chunked-prefill-size
+            - '131072'
+            - --watchdog-timeout
+            - '1200'
+            - --speculative-algorithm
+            - EAGLE
+            - --speculative-num-steps
+            - '3'
+            - --speculative-eagle-topk
+            - '1'
+            - --speculative-num-draft-tokens
+            - '4'
+          prefill: null
+          decode: null
       MI355X:
         configurations:
         - name: default
@@ -250,6 +358,60 @@ families:
             - '131072'
             - --watchdog-timeout
             - '1200'
+          prefill: null
+          decode: null
+        - name: high-throughput-dp
+          attributes:
+            nodes: single
+            optimization: high-throughput
+            quantization: bf16
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: 8
+            ep: null
+            enable_dp_attention: true
+            extra_args:
+            - --nsa-prefill-backend
+            - tilelang
+            - --nsa-decode-backend
+            - tilelang
+            - --chunked-prefill-size
+            - '131072'
+            - --watchdog-timeout
+            - '1200'
+          prefill: null
+          decode: null
+        - name: speculative-mtp
+          attributes:
+            nodes: single
+            optimization: low-latency
+            quantization: bf16
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --nsa-prefill-backend
+            - tilelang
+            - --nsa-decode-backend
+            - tilelang
+            - --chunked-prefill-size
+            - '131072'
+            - --watchdog-timeout
+            - '1200'
+            - --speculative-algorithm
+            - EAGLE
+            - --speculative-num-steps
+            - '3'
+            - --speculative-eagle-topk
+            - '1'
+            - --speculative-num-draft-tokens
+            - '4'
           prefill: null
           decode: null
   - name: GLM-5.1-FP8
@@ -341,6 +503,60 @@ families:
             - '1200'
           prefill: null
           decode: null
+        - name: high-throughput-dp
+          attributes:
+            nodes: single
+            optimization: high-throughput
+            quantization: fp8
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: 8
+            ep: null
+            enable_dp_attention: true
+            extra_args:
+            - --nsa-prefill-backend
+            - tilelang
+            - --nsa-decode-backend
+            - tilelang
+            - --chunked-prefill-size
+            - '131072'
+            - --watchdog-timeout
+            - '1200'
+          prefill: null
+          decode: null
+        - name: speculative-mtp
+          attributes:
+            nodes: single
+            optimization: low-latency
+            quantization: fp8
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --nsa-prefill-backend
+            - tilelang
+            - --nsa-decode-backend
+            - tilelang
+            - --chunked-prefill-size
+            - '131072'
+            - --watchdog-timeout
+            - '1200'
+            - --speculative-algorithm
+            - EAGLE
+            - --speculative-num-steps
+            - '3'
+            - --speculative-eagle-topk
+            - '1'
+            - --speculative-num-draft-tokens
+            - '4'
+          prefill: null
+          decode: null
       MI325X:
         configurations:
         - name: default
@@ -366,6 +582,60 @@ families:
             - '1200'
           prefill: null
           decode: null
+        - name: high-throughput-dp
+          attributes:
+            nodes: single
+            optimization: high-throughput
+            quantization: fp8
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 4
+            dp: 8
+            ep: null
+            enable_dp_attention: true
+            extra_args:
+            - --nsa-prefill-backend
+            - tilelang
+            - --nsa-decode-backend
+            - tilelang
+            - --chunked-prefill-size
+            - '131072'
+            - --watchdog-timeout
+            - '1200'
+          prefill: null
+          decode: null
+        - name: speculative-mtp
+          attributes:
+            nodes: single
+            optimization: low-latency
+            quantization: fp8
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 4
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --nsa-prefill-backend
+            - tilelang
+            - --nsa-decode-backend
+            - tilelang
+            - --chunked-prefill-size
+            - '131072'
+            - --watchdog-timeout
+            - '1200'
+            - --speculative-algorithm
+            - EAGLE
+            - --speculative-num-steps
+            - '3'
+            - --speculative-eagle-topk
+            - '1'
+            - --speculative-num-draft-tokens
+            - '4'
+          prefill: null
+          decode: null
       MI355X:
         configurations:
         - name: default
@@ -389,6 +659,60 @@ families:
             - '131072'
             - --watchdog-timeout
             - '1200'
+          prefill: null
+          decode: null
+        - name: high-throughput-dp
+          attributes:
+            nodes: single
+            optimization: high-throughput
+            quantization: fp8
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 4
+            dp: 8
+            ep: null
+            enable_dp_attention: true
+            extra_args:
+            - --nsa-prefill-backend
+            - tilelang
+            - --nsa-decode-backend
+            - tilelang
+            - --chunked-prefill-size
+            - '131072'
+            - --watchdog-timeout
+            - '1200'
+          prefill: null
+          decode: null
+        - name: speculative-mtp
+          attributes:
+            nodes: single
+            optimization: low-latency
+            quantization: fp8
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 4
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --nsa-prefill-backend
+            - tilelang
+            - --nsa-decode-backend
+            - tilelang
+            - --chunked-prefill-size
+            - '131072'
+            - --watchdog-timeout
+            - '1200'
+            - --speculative-algorithm
+            - EAGLE
+            - --speculative-num-steps
+            - '3'
+            - --speculative-eagle-topk
+            - '1'
+            - --speculative-num-draft-tokens
+            - '4'
           prefill: null
           decode: null
   - name: GLM-5.1-MXFP4
@@ -419,6 +743,10 @@ families:
             - tilelang
             - --nsa-decode-backend
             - tilelang
+            - --chunked-prefill-size
+            - '131072'
+            - --watchdog-timeout
+            - '1200'
             - --kv-cache-dtype
             - fp8_e4m3
             - --model-loader-extra-config

--- a/data/models/generated/v0.5.10/glm51.yaml
+++ b/data/models/generated/v0.5.10/glm51.yaml
@@ -192,10 +192,8 @@ families:
             ep: null
             enable_dp_attention: null
             extra_args:
-            - --nsa-prefill-backend
-            - tilelang
-            - --nsa-decode-backend
-            - tilelang
+            - --model-loader-extra-config
+            - '{"enable_multithread_load": true, "num_threads": 8}'
             - --chunked-prefill-size
             - '131072'
             - --watchdog-timeout
@@ -205,30 +203,7 @@ families:
         - name: high-throughput-dp
           attributes:
             nodes: single
-            optimization: high-throughput
-            quantization: bf16
-          quantized_model_path: null
-          engine:
-            env_vars: {}
-            tp: 8
-            dp: 8
-            ep: null
-            enable_dp_attention: true
-            extra_args:
-            - --nsa-prefill-backend
-            - tilelang
-            - --nsa-decode-backend
-            - tilelang
-            - --chunked-prefill-size
-            - '131072'
-            - --watchdog-timeout
-            - '1200'
-          prefill: null
-          decode: null
-        - name: speculative-mtp
-          attributes:
-            nodes: single
-            optimization: low-latency
+            optimization: balanced
             quantization: bf16
           quantized_model_path: null
           engine:
@@ -238,22 +213,12 @@ families:
             ep: null
             enable_dp_attention: null
             extra_args:
-            - --nsa-prefill-backend
-            - tilelang
-            - --nsa-decode-backend
-            - tilelang
+            - --model-loader-extra-config
+            - '{"enable_multithread_load": true, "num_threads": 8}'
             - --chunked-prefill-size
             - '131072'
             - --watchdog-timeout
             - '1200'
-            - --speculative-algorithm
-            - EAGLE
-            - --speculative-num-steps
-            - '3'
-            - --speculative-eagle-topk
-            - '1'
-            - --speculative-num-draft-tokens
-            - '4'
           prefill: null
           decode: null
       MI325X:
@@ -271,10 +236,8 @@ families:
             ep: null
             enable_dp_attention: null
             extra_args:
-            - --nsa-prefill-backend
-            - tilelang
-            - --nsa-decode-backend
-            - tilelang
+            - --model-loader-extra-config
+            - '{"enable_multithread_load": true, "num_threads": 8}'
             - --chunked-prefill-size
             - '131072'
             - --watchdog-timeout
@@ -284,30 +247,7 @@ families:
         - name: high-throughput-dp
           attributes:
             nodes: single
-            optimization: high-throughput
-            quantization: bf16
-          quantized_model_path: null
-          engine:
-            env_vars: {}
-            tp: 8
-            dp: 8
-            ep: null
-            enable_dp_attention: true
-            extra_args:
-            - --nsa-prefill-backend
-            - tilelang
-            - --nsa-decode-backend
-            - tilelang
-            - --chunked-prefill-size
-            - '131072'
-            - --watchdog-timeout
-            - '1200'
-          prefill: null
-          decode: null
-        - name: speculative-mtp
-          attributes:
-            nodes: single
-            optimization: low-latency
+            optimization: balanced
             quantization: bf16
           quantized_model_path: null
           engine:
@@ -317,22 +257,12 @@ families:
             ep: null
             enable_dp_attention: null
             extra_args:
-            - --nsa-prefill-backend
-            - tilelang
-            - --nsa-decode-backend
-            - tilelang
+            - --model-loader-extra-config
+            - '{"enable_multithread_load": true, "num_threads": 8}'
             - --chunked-prefill-size
             - '131072'
             - --watchdog-timeout
             - '1200'
-            - --speculative-algorithm
-            - EAGLE
-            - --speculative-num-steps
-            - '3'
-            - --speculative-eagle-topk
-            - '1'
-            - --speculative-num-draft-tokens
-            - '4'
           prefill: null
           decode: null
       MI355X:
@@ -350,10 +280,8 @@ families:
             ep: null
             enable_dp_attention: null
             extra_args:
-            - --nsa-prefill-backend
-            - tilelang
-            - --nsa-decode-backend
-            - tilelang
+            - --model-loader-extra-config
+            - '{"enable_multithread_load": true, "num_threads": 8}'
             - --chunked-prefill-size
             - '131072'
             - --watchdog-timeout
@@ -363,30 +291,7 @@ families:
         - name: high-throughput-dp
           attributes:
             nodes: single
-            optimization: high-throughput
-            quantization: bf16
-          quantized_model_path: null
-          engine:
-            env_vars: {}
-            tp: 8
-            dp: 8
-            ep: null
-            enable_dp_attention: true
-            extra_args:
-            - --nsa-prefill-backend
-            - tilelang
-            - --nsa-decode-backend
-            - tilelang
-            - --chunked-prefill-size
-            - '131072'
-            - --watchdog-timeout
-            - '1200'
-          prefill: null
-          decode: null
-        - name: speculative-mtp
-          attributes:
-            nodes: single
-            optimization: low-latency
+            optimization: balanced
             quantization: bf16
           quantized_model_path: null
           engine:
@@ -396,22 +301,12 @@ families:
             ep: null
             enable_dp_attention: null
             extra_args:
-            - --nsa-prefill-backend
-            - tilelang
-            - --nsa-decode-backend
-            - tilelang
+            - --model-loader-extra-config
+            - '{"enable_multithread_load": true, "num_threads": 8}'
             - --chunked-prefill-size
             - '131072'
             - --watchdog-timeout
             - '1200'
-            - --speculative-algorithm
-            - EAGLE
-            - --speculative-num-steps
-            - '3'
-            - --speculative-eagle-topk
-            - '1'
-            - --speculative-num-draft-tokens
-            - '4'
           prefill: null
           decode: null
   - name: GLM-5.1-FP8
@@ -493,10 +388,8 @@ families:
             ep: null
             enable_dp_attention: null
             extra_args:
-            - --nsa-prefill-backend
-            - tilelang
-            - --nsa-decode-backend
-            - tilelang
+            - --model-loader-extra-config
+            - '{"enable_multithread_load": true, "num_threads": 8}'
             - --chunked-prefill-size
             - '131072'
             - --watchdog-timeout
@@ -506,30 +399,7 @@ families:
         - name: high-throughput-dp
           attributes:
             nodes: single
-            optimization: high-throughput
-            quantization: fp8
-          quantized_model_path: null
-          engine:
-            env_vars: {}
-            tp: 8
-            dp: 8
-            ep: null
-            enable_dp_attention: true
-            extra_args:
-            - --nsa-prefill-backend
-            - tilelang
-            - --nsa-decode-backend
-            - tilelang
-            - --chunked-prefill-size
-            - '131072'
-            - --watchdog-timeout
-            - '1200'
-          prefill: null
-          decode: null
-        - name: speculative-mtp
-          attributes:
-            nodes: single
-            optimization: low-latency
+            optimization: balanced
             quantization: fp8
           quantized_model_path: null
           engine:
@@ -539,22 +409,12 @@ families:
             ep: null
             enable_dp_attention: null
             extra_args:
-            - --nsa-prefill-backend
-            - tilelang
-            - --nsa-decode-backend
-            - tilelang
+            - --model-loader-extra-config
+            - '{"enable_multithread_load": true, "num_threads": 8}'
             - --chunked-prefill-size
             - '131072'
             - --watchdog-timeout
             - '1200'
-            - --speculative-algorithm
-            - EAGLE
-            - --speculative-num-steps
-            - '3'
-            - --speculative-eagle-topk
-            - '1'
-            - --speculative-num-draft-tokens
-            - '4'
           prefill: null
           decode: null
       MI325X:
@@ -572,10 +432,8 @@ families:
             ep: null
             enable_dp_attention: null
             extra_args:
-            - --nsa-prefill-backend
-            - tilelang
-            - --nsa-decode-backend
-            - tilelang
+            - --model-loader-extra-config
+            - '{"enable_multithread_load": true, "num_threads": 8}'
             - --chunked-prefill-size
             - '131072'
             - --watchdog-timeout
@@ -585,30 +443,7 @@ families:
         - name: high-throughput-dp
           attributes:
             nodes: single
-            optimization: high-throughput
-            quantization: fp8
-          quantized_model_path: null
-          engine:
-            env_vars: {}
-            tp: 4
-            dp: 8
-            ep: null
-            enable_dp_attention: true
-            extra_args:
-            - --nsa-prefill-backend
-            - tilelang
-            - --nsa-decode-backend
-            - tilelang
-            - --chunked-prefill-size
-            - '131072'
-            - --watchdog-timeout
-            - '1200'
-          prefill: null
-          decode: null
-        - name: speculative-mtp
-          attributes:
-            nodes: single
-            optimization: low-latency
+            optimization: balanced
             quantization: fp8
           quantized_model_path: null
           engine:
@@ -618,22 +453,12 @@ families:
             ep: null
             enable_dp_attention: null
             extra_args:
-            - --nsa-prefill-backend
-            - tilelang
-            - --nsa-decode-backend
-            - tilelang
+            - --model-loader-extra-config
+            - '{"enable_multithread_load": true, "num_threads": 8}'
             - --chunked-prefill-size
             - '131072'
             - --watchdog-timeout
             - '1200'
-            - --speculative-algorithm
-            - EAGLE
-            - --speculative-num-steps
-            - '3'
-            - --speculative-eagle-topk
-            - '1'
-            - --speculative-num-draft-tokens
-            - '4'
           prefill: null
           decode: null
       MI355X:
@@ -651,10 +476,8 @@ families:
             ep: null
             enable_dp_attention: null
             extra_args:
-            - --nsa-prefill-backend
-            - tilelang
-            - --nsa-decode-backend
-            - tilelang
+            - --model-loader-extra-config
+            - '{"enable_multithread_load": true, "num_threads": 8}'
             - --chunked-prefill-size
             - '131072'
             - --watchdog-timeout
@@ -664,30 +487,7 @@ families:
         - name: high-throughput-dp
           attributes:
             nodes: single
-            optimization: high-throughput
-            quantization: fp8
-          quantized_model_path: null
-          engine:
-            env_vars: {}
-            tp: 4
-            dp: 8
-            ep: null
-            enable_dp_attention: true
-            extra_args:
-            - --nsa-prefill-backend
-            - tilelang
-            - --nsa-decode-backend
-            - tilelang
-            - --chunked-prefill-size
-            - '131072'
-            - --watchdog-timeout
-            - '1200'
-          prefill: null
-          decode: null
-        - name: speculative-mtp
-          attributes:
-            nodes: single
-            optimization: low-latency
+            optimization: balanced
             quantization: fp8
           quantized_model_path: null
           engine:
@@ -697,22 +497,12 @@ families:
             ep: null
             enable_dp_attention: null
             extra_args:
-            - --nsa-prefill-backend
-            - tilelang
-            - --nsa-decode-backend
-            - tilelang
+            - --model-loader-extra-config
+            - '{"enable_multithread_load": true, "num_threads": 8}'
             - --chunked-prefill-size
             - '131072'
             - --watchdog-timeout
             - '1200'
-            - --speculative-algorithm
-            - EAGLE
-            - --speculative-num-steps
-            - '3'
-            - --speculative-eagle-topk
-            - '1'
-            - --speculative-num-draft-tokens
-            - '4'
           prefill: null
           decode: null
   - name: GLM-5.1-MXFP4
@@ -739,20 +529,18 @@ families:
             ep: null
             enable_dp_attention: null
             extra_args:
-            - --nsa-prefill-backend
-            - tilelang
-            - --nsa-decode-backend
-            - tilelang
+            - --model-loader-extra-config
+            - '{"enable_multithread_load": true, "num_threads": 8}'
             - --chunked-prefill-size
             - '131072'
             - --watchdog-timeout
             - '1200'
+            - --nsa-prefill-backend
+            - tilelang
+            - --nsa-decode-backend
+            - tilelang
             - --kv-cache-dtype
             - fp8_e4m3
-            - --model-loader-extra-config
-            - '{"enable_multithread_load": true, "num_threads": 8}'
-            - --tokenizer-worker-num
-            - '4'
             - --disable-radix-cache
           prefill: null
           decode: null

--- a/data/models/generated/v0.5.10/glm51.yaml
+++ b/data/models/generated/v0.5.10/glm51.yaml
@@ -177,6 +177,81 @@ families:
             - '4'
           prefill: null
           decode: null
+      MI300X:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: bf16
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --nsa-prefill-backend
+            - tilelang
+            - --nsa-decode-backend
+            - tilelang
+            - --chunked-prefill-size
+            - '131072'
+            - --watchdog-timeout
+            - '1200'
+          prefill: null
+          decode: null
+      MI325X:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: bf16
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --nsa-prefill-backend
+            - tilelang
+            - --nsa-decode-backend
+            - tilelang
+            - --chunked-prefill-size
+            - '131072'
+            - --watchdog-timeout
+            - '1200'
+          prefill: null
+          decode: null
+      MI355X:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: bf16
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --nsa-prefill-backend
+            - tilelang
+            - --nsa-decode-backend
+            - tilelang
+            - --chunked-prefill-size
+            - '131072'
+            - --watchdog-timeout
+            - '1200'
+          prefill: null
+          decode: null
   - name: GLM-5.1-FP8
     model_path: zai-org/GLM-5.1-FP8
     attributes:
@@ -239,5 +314,117 @@ families:
             - '1'
             - --speculative-num-draft-tokens
             - '4'
+          prefill: null
+          decode: null
+      MI300X:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: fp8
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --nsa-prefill-backend
+            - tilelang
+            - --nsa-decode-backend
+            - tilelang
+            - --chunked-prefill-size
+            - '131072'
+            - --watchdog-timeout
+            - '1200'
+          prefill: null
+          decode: null
+      MI325X:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: fp8
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 4
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --nsa-prefill-backend
+            - tilelang
+            - --nsa-decode-backend
+            - tilelang
+            - --chunked-prefill-size
+            - '131072'
+            - --watchdog-timeout
+            - '1200'
+          prefill: null
+          decode: null
+      MI355X:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: fp8
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 4
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --nsa-prefill-backend
+            - tilelang
+            - --nsa-decode-backend
+            - tilelang
+            - --chunked-prefill-size
+            - '131072'
+            - --watchdog-timeout
+            - '1200'
+          prefill: null
+          decode: null
+  - name: GLM-5.1-MXFP4
+    model_path: amd/GLM-5.1-MXFP4
+    attributes:
+      llm:
+        thinking_capability: hybrid
+        tool_parser: glm47
+        reasoning_parser: glm45
+        chat_template: null
+    hardware:
+      MI355X:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: fp4
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 2
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --nsa-prefill-backend
+            - tilelang
+            - --nsa-decode-backend
+            - tilelang
+            - --kv-cache-dtype
+            - fp8_e4m3
+            - --model-loader-extra-config
+            - '{"enable_multithread_load": true, "num_threads": 8}'
+            - --tokenizer-worker-num
+            - '4'
+            - --disable-radix-cache
           prefill: null
           decode: null

--- a/data/models/src/v0.5.10/glm51.yaml
+++ b/data/models/src/v0.5.10/glm51.yaml
@@ -6,6 +6,9 @@
 #   H200: FP8 tp=8, BF16 tp=16
 #   B200: FP8 tp=8, BF16 tp=16
 #   GB300: FP8 tp=4
+#   MI300X: BF16 tp=8, FP8 tp=8
+#   MI325X: BF16 tp=8, FP8 tp=4
+#   MI355X: BF16 tp=8, FP8 tp=4, MXFP4 tp=2
 
 vendor: zai-org
 
@@ -15,6 +18,39 @@ defaults:
     H200: { tp: 8 }
     B200: { tp: 8 }
     GB300: { tp: 4 }
+    MI300X:
+      tp: 8
+      extra_args:
+        - --nsa-prefill-backend
+        - tilelang
+        - --nsa-decode-backend
+        - tilelang
+        - --chunked-prefill-size
+        - "131072"
+        - --watchdog-timeout
+        - "1200"
+    MI325X:
+      tp: 8
+      extra_args:
+        - --nsa-prefill-backend
+        - tilelang
+        - --nsa-decode-backend
+        - tilelang
+        - --chunked-prefill-size
+        - "131072"
+        - --watchdog-timeout
+        - "1200"
+    MI355X:
+      tp: 8
+      extra_args:
+        - --nsa-prefill-backend
+        - tilelang
+        - --nsa-decode-backend
+        - tilelang
+        - --chunked-prefill-size
+        - "131072"
+        - --watchdog-timeout
+        - "1200"
   configurations:
     - name: default
       nodes: single
@@ -53,6 +89,9 @@ families:
           H100: { tp: 32 }
           H200: { tp: 16 }
           B200: { tp: 16 }
+          MI300X: {}  # Uses defaults: tp=8 with TileLang backends
+          MI325X: {}  # Uses defaults: tp=8 with TileLang backends
+          MI355X: {}  # Uses defaults: tp=8 with TileLang backends
 
       # GLM-5.1 FP8
       - name: GLM-5.1-FP8
@@ -81,3 +120,30 @@ families:
                   - "1"
                   - --speculative-num-draft-tokens
                   - "4"
+          MI300X: {}  # Uses defaults: tp=8 with TileLang backends
+          MI325X: { tp: 4 }  # Override: tp=4 (uses default extra_args)
+          MI355X: { tp: 4 }  # Override: tp=4 (uses default extra_args)
+
+      # GLM-5.1 MXFP4 - AMD MI355X only
+      - name: GLM-5.1-MXFP4
+        model_path: amd/GLM-5.1-MXFP4
+        quantization: fp4
+        hardware:
+          MI355X:
+            tp: 2
+            configurations:
+              - name: default
+                nodes: single
+                optimization: balanced
+                extra_args:
+                  - --nsa-prefill-backend
+                  - tilelang
+                  - --nsa-decode-backend
+                  - tilelang
+                  - --kv-cache-dtype
+                  - fp8_e4m3
+                  - --model-loader-extra-config
+                  - '{"enable_multithread_load": true, "num_threads": 8}'
+                  - --tokenizer-worker-num
+                  - "4"
+                  - --disable-radix-cache

--- a/data/models/src/v0.5.10/glm51.yaml
+++ b/data/models/src/v0.5.10/glm51.yaml
@@ -21,10 +21,8 @@ defaults:
     MI300X:
       tp: 8
       extra_args:
-        - --nsa-prefill-backend
-        - tilelang
-        - --nsa-decode-backend
-        - tilelang
+        - --model-loader-extra-config
+        - '{"enable_multithread_load": true, "num_threads": 8}'
         - --chunked-prefill-size
         - "131072"
         - --watchdog-timeout
@@ -32,10 +30,8 @@ defaults:
     MI325X:
       tp: 8
       extra_args:
-        - --nsa-prefill-backend
-        - tilelang
-        - --nsa-decode-backend
-        - tilelang
+        - --model-loader-extra-config
+        - '{"enable_multithread_load": true, "num_threads": 8}'
         - --chunked-prefill-size
         - "131072"
         - --watchdog-timeout
@@ -43,10 +39,8 @@ defaults:
     MI355X:
       tp: 8
       extra_args:
-        - --nsa-prefill-backend
-        - tilelang
-        - --nsa-decode-backend
-        - tilelang
+        - --model-loader-extra-config
+        - '{"enable_multithread_load": true, "num_threads": 8}'
         - --chunked-prefill-size
         - "131072"
         - --watchdog-timeout
@@ -89,9 +83,18 @@ families:
           H100: { tp: 32 }
           H200: { tp: 16 }
           B200: { tp: 16 }
-          MI300X: {}  # Uses defaults: tp=8 with TileLang backends
-          MI325X: {}  # Uses defaults: tp=8 with TileLang backends
-          MI355X: {}  # Uses defaults: tp=8 with TileLang backends
+          MI300X:
+            configurations:
+              - name: default
+              - name: high-throughput-dp
+          MI325X:
+            configurations:
+              - name: default
+              - name: high-throughput-dp
+          MI355X:
+            configurations:
+              - name: default
+              - name: high-throughput-dp
 
       # GLM-5.1 FP8
       - name: GLM-5.1-FP8
@@ -120,9 +123,20 @@ families:
                   - "1"
                   - --speculative-num-draft-tokens
                   - "4"
-          MI300X: {}  # Uses defaults: tp=8 with TileLang backends
-          MI325X: { tp: 4 }  # Override: tp=4 (uses default extra_args)
-          MI355X: { tp: 4 }  # Override: tp=4 (uses default extra_args)
+          MI300X:
+            configurations:
+              - name: default
+              - name: high-throughput-dp
+          MI325X:
+            tp: 4
+            configurations:
+              - name: default
+              - name: high-throughput-dp
+          MI355X:
+            tp: 4
+            configurations:
+              - name: default
+              - name: high-throughput-dp
 
       # GLM-5.1 MXFP4 - AMD MI355X only
       - name: GLM-5.1-MXFP4
@@ -142,8 +156,4 @@ families:
                   - tilelang
                   - --kv-cache-dtype
                   - fp8_e4m3
-                  - --model-loader-extra-config
-                  - '{"enable_multithread_load": true, "num_threads": 8}'
-                  - --tokenizer-worker-num
-                  - "4"
                   - --disable-radix-cache

--- a/docs/autoregressive/GLM/GLM-5.1.md
+++ b/docs/autoregressive/GLM/GLM-5.1.md
@@ -54,7 +54,7 @@ import GLM51ConfigGenerator from '@site/src/components/autoregressive/GLM51Confi
 | MI325X   | 8       | 4      | N/A    |
 | MI355X   | 8       | 4      | 2      |
 
-- **AMD GPUs**: Both BF16 and FP8 checkpoints are supported on MI300X/MI325X/MI355X at tp=8. Use `--nsa-prefill-backend tilelang --nsa-decode-backend tilelang` for the NSA attention backend. Add `--chunked-prefill-size 131072` and `--watchdog-timeout 1200` (20 minutes for weight loading). FP8 uses approximately half the memory of BF16 (~89 GB/GPU vs ~175 GB/GPU). EAGLE speculative decoding is not currently supported on AMD for GLM-5.1.
+- **AMD GPUs**: Both BF16 and FP8 checkpoints are supported on MI300X/MI325X/MI355X. FP8 uses approximately half the memory of BF16 (~89 GB/GPU vs ~175 GB/GPU). Required flags: `--trust-remote-code`, `--model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 8}'`, `--chunked-prefill-size 131072`, `--watchdog-timeout 1200` (20 minutes for weight loading), and `--tokenizer-worker-num` (set to 2× the TP value). MXFP4 additionally requires `--nsa-prefill-backend tilelang`, `--nsa-decode-backend tilelang`, `--disable-radix-cache`, and `--kv-cache-dtype fp8_e4m3`. EAGLE speculative decoding is not currently supported on AMD for GLM-5.1.
 - **GB300**: Only the FP8 checkpoint is recommended on GB300, with `tp=4`. For high-throughput DP attention on GB300, use `--dp 4`.
 - For other configuration tips, please refer to [DeepSeek V3.2 documentation](https://docs.sglang.io/basic_usage/deepseek_v32.html). GLM-5.1 and DeepSeek V3.2 share the same model structure, so the optimization techniques between these two models are also common (MTP, DSA kernel, Context Parallel...).
 - Use `--json-model-override-args '{"index_topk_pattern": "FFSFSSSFSSFFFSSSFFFSFSSSSSSFFSFFSFFSSFFFFFFSFFFFFSFFSSSSSSFSFFFSFSSSFSFFSFFSSS"}'` for GLM-5.1-FP8 if you want to enable the [IndexCache](https://github.com/THUDM/IndexCache) method. This feature is supported through [this PR](https://github.com/sgl-project/sglang/pull/21405) and introduces only a small accuracy loss. However, if you are running rigorous accuracy evaluations, it is not recommended to enable this feature.
@@ -82,7 +82,7 @@ SGLANG_ENABLE_SPEC_V2=1 sglang serve \
 
 The following ROCm commands are additional options for AMD GPUs and do not replace the NVIDIA instructions above.
 
-#### FP8 (Recommended)
+#### FP8
 
 ```shell
 sglang serve \
@@ -91,11 +91,11 @@ sglang serve \
   --trust-remote-code \
   --tool-call-parser glm47 \
   --reasoning-parser glm45 \
-  --nsa-prefill-backend tilelang \
-  --nsa-decode-backend tilelang \
+  --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 8}' \
   --chunked-prefill-size 131072 \
-  --mem-fraction-static 0.80 \
   --watchdog-timeout 1200 \
+  --tokenizer-worker-num 16 \
+  --mem-fraction-static 0.85 \
   --host 0.0.0.0 \
   --port 30000
 ```
@@ -107,11 +107,11 @@ sglang serve \
   --model-path zai-org/GLM-5.1 \
   --tp 8 \
   --trust-remote-code \
-  --nsa-prefill-backend tilelang \
-  --nsa-decode-backend tilelang \
+  --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 8}' \
   --chunked-prefill-size 131072 \
-  --mem-fraction-static 0.80 \
   --watchdog-timeout 1200 \
+  --tokenizer-worker-num 16 \
+  --mem-fraction-static 0.80 \
   --host 0.0.0.0 \
   --port 30000
 ```

--- a/docs/autoregressive/GLM/GLM-5.1.md
+++ b/docs/autoregressive/GLM/GLM-5.1.md
@@ -6,12 +6,23 @@
 
 - **BF16 (Full precision)**: [zai-org/GLM-5.1](https://huggingface.co/zai-org/GLM-5.1)
 - **FP8 (8-bit quantized)**: [zai-org/GLM-5.1-FP8](https://huggingface.co/zai-org/GLM-5.1-FP8)
+- **FP4 (4-bit quantized)**: [amd/GLM-5.1-MXFP4](https://huggingface.co/amd/GLM-5.1-MXFP4) **(AMD Only)**
 
 **License:** MIT
 
 ## 2. SGLang Installation
 
 Please refer to the [official SGLang installation guide](https://docs.sglang.ai/get_started/install.html) for installation instructions.
+
+### AMD Docker Images
+
+```bash
+# Use Docker (AMD MI300X/MI325X)
+docker pull lmsysorg/sglang-rocm:v0.5.10rc0-rocm720-mi30x-20260415
+
+# Use Docker (AMD MI355X)
+docker pull lmsysorg/sglang-rocm:v0.5.10rc0-rocm720-mi35x-20260415
+```
 
 ## 3. Model Deployment
 
@@ -33,14 +44,15 @@ import GLM51ConfigGenerator from '@site/src/components/autoregressive/GLM51Confi
 - The `--mem-fraction-static` flag is recommended for optimal memory utilization, adjust it based on your hardware and workload.
 - BF16 model always requires **2x GPUs** compared to FP8 on NVIDIA hardware.
 
-| Hardware | FP8 | BF16 |
-| -------- | --- | ---- |
-| H100     | tp=16 | tp=32 |
-| H200     | tp=8  | tp=16 |
-| B200     | tp=8  | tp=16 |
-| GB300    | tp=4  | —     |
-| MI300X/MI325X | tp=8 | tp=8 |
-| MI355X   | tp=8 | tp=8 |
+| Hardware | BF16 TP | FP8 TP | FP4 TP |
+| -------- | ------- | ------ | ------ |
+| H100     | 32      | 16     | N/A    |
+| H200     | 16      | 8      | N/A    |
+| B200     | 16      | 8      | N/A    |
+| GB300    | N/A     | 4      | N/A    |
+| MI300X   | 8       | 8      | N/A    |
+| MI325X   | 8       | 4      | N/A    |
+| MI355X   | 8       | 4      | 2      |
 
 - **AMD GPUs**: Both BF16 and FP8 checkpoints are supported on MI300X/MI325X/MI355X at tp=8. Use `--nsa-prefill-backend tilelang --nsa-decode-backend tilelang` for the NSA attention backend. Add `--chunked-prefill-size 131072` and `--watchdog-timeout 1200` (20 minutes for weight loading). FP8 uses approximately half the memory of BF16 (~89 GB/GPU vs ~175 GB/GPU). EAGLE speculative decoding is not currently supported on AMD for GLM-5.1.
 - **GB300**: Only the FP8 checkpoint is recommended on GB300, with `tp=4`. For high-throughput DP attention on GB300, use `--dp 4`.

--- a/src/components/autoregressive/GLM51ConfigGenerator/index.js
+++ b/src/components/autoregressive/GLM51ConfigGenerator/index.js
@@ -4,15 +4,16 @@ import ConfigGenerator from '../../base/ConfigGenerator';
 /**
  * GLM-5.1 Configuration Generator
  * Supports GLM-5.1 744B (40B active) MoE model deployment configuration
- * with BF16/FP8 quantization, reasoning parser, DP attention, and speculative decoding
+ * with BF16/FP8/MXFP4 quantization, reasoning parser, DP attention, and speculative decoding
  *
  * GPU requirements (BF16 needs 2x GPUs compared to FP8):
  *   H100: FP8 tp=16, BF16 tp=32
  *   H200: FP8 tp=8, BF16 tp=16
  *   B200: FP8 tp=8, BF16 tp=16
  *   GB300: FP8 tp=4
- *   MI300X/MI325X: BF16 tp=8
- *   MI355X: BF16 tp=8
+ *   MI300X: BF16 tp=8, FP8 tp=8
+ *   MI325X: BF16 tp=8, FP8 tp=4
+ *   MI355X: BF16 tp=8, FP8 tp=4, MXFP4 tp=2
  */
 const GLM51ConfigGenerator = () => {
   const config = {
@@ -23,11 +24,12 @@ const GLM51ConfigGenerator = () => {
         name: 'hardware',
         title: 'Hardware Platform',
         items: [
-          { id: 'h200', label: 'H200', default: true },
+          { id: 'h200', label: 'H200', default: false },
           { id: 'b200', label: 'B200', default: false },
           { id: 'gb300', label: 'GB300', default: false },
           { id: 'h100', label: 'H100', default: false },
-          { id: 'mi300x', label: 'MI300X/MI325X', default: false },
+          { id: 'mi300x', label: 'MI300X', default: true },
+          { id: 'mi325x', label: 'MI325X', default: false },
           { id: 'mi355x', label: 'MI355X', default: false }
         ]
       },
@@ -36,8 +38,10 @@ const GLM51ConfigGenerator = () => {
         title: 'Quantization',
         getDynamicItems: (values) => {
           const hw = values.hardware;
-          const isAMD = hw === 'mi300x' || hw === 'mi355x';
+          const isAMD = hw === 'mi300x' || hw === 'mi325x' || hw === 'mi355x';
+          const isMI355X = hw === 'mi355x';
           const isGB300 = hw === 'gb300';
+
           return [
             {
               id: 'bf16',
@@ -47,7 +51,15 @@ const GLM51ConfigGenerator = () => {
               disabled: isGB300,
               disabledReason: isGB300 ? 'BF16 is not recommended on GB300 for GLM-5.1' : ''
             },
-            { id: 'fp8', label: 'FP8', subtitle: 'High Throughput', default: !isAMD, disabled: isAMD, disabledReason: isAMD ? 'FP8 not verified on AMD' : '' }
+            { id: 'fp8', label: 'FP8', subtitle: 'High Throughput', default: !isAMD },
+            {
+              id: 'mxfp4',
+              label: 'FP4',
+              subtitle: 'Ultra Low Memory',
+              default: false,
+              disabled: !isMI355X,
+              disabledReason: !isMI355X ? 'FP4 is only supported on AMD MI355X GPU' : ''
+            }
           ];
         }
       },
@@ -55,8 +67,8 @@ const GLM51ConfigGenerator = () => {
         name: 'reasoning',
         title: 'Reasoning Parser',
         items: [
-          { id: 'disabled', label: 'Disabled', default: false },
-          { id: 'enabled', label: 'Enabled', default: true }
+          { id: 'disabled', label: 'Disabled', default: true },
+          { id: 'enabled', label: 'Enabled', default: false }
         ],
         commandRule: (value) => (value === 'enabled' ? '--reasoning-parser glm45' : null)
       },
@@ -64,8 +76,8 @@ const GLM51ConfigGenerator = () => {
         name: 'toolcall',
         title: 'Tool Call Parser',
         items: [
-          { id: 'disabled', label: 'Disabled', default: false },
-          { id: 'enabled', label: 'Enabled', default: true }
+          { id: 'disabled', label: 'Disabled', default: true },
+          { id: 'enabled', label: 'Enabled', default: false }
         ],
         commandRule: (value) => (value === 'enabled' ? '--tool-call-parser glm47' : null)
       },
@@ -80,11 +92,10 @@ const GLM51ConfigGenerator = () => {
       },
       speculative: {
         name: 'speculative',
-        title: 'Speculative Decoding',
-        condition: (values) => values.hardware !== 'mi300x' && values.hardware !== 'mi355x',
+        title: 'Speculative Decoding (MTP)',
         items: [
-          { id: 'disabled', label: 'Disabled', default: false },
-          { id: 'enabled', label: 'Enabled', default: true }
+          { id: 'disabled', label: 'Disabled', default: true },
+          { id: 'enabled', label: 'Enabled', default: false }
         ],
         commandRule: (value) => (value === 'enabled'
           ? '--speculative-algorithm EAGLE \\\n  --speculative-num-steps 3 \\\n  --speculative-eagle-topk 1 \\\n  --speculative-num-draft-tokens 4'
@@ -97,17 +108,29 @@ const GLM51ConfigGenerator = () => {
       h200: { fp8: { tp: 8, mem: 0.85 }, bf16: { tp: 16, mem: 0.85 } },
       b200: { fp8: { tp: 8, mem: 0.9 }, bf16: { tp: 16, mem: 0.9 } },
       gb300: { fp8: { tp: 4, mem: 0.9 } },
-      mi300x: { bf16: { tp: 8, mem: 0.8 } },
-      mi355x: { bf16: { tp: 8, mem: 0.8 } }
+      mi300x: { bf16: { tp: 8, mem: 0.8 }, fp8: { tp: 8, mem: 0.85 } },
+      mi325x: { bf16: { tp: 8, mem: 0.8 }, fp8: { tp: 4, mem: 0.85 } },
+      mi355x: { bf16: { tp: 8, mem: 0.8 }, fp8: { tp: 4, mem: 0.85 }, mxfp4: { tp: 2, mem: 0.85 } }
     },
 
     generateCommand: function (values) {
       const { hardware, quantization } = values;
-      const isAMD = hardware === 'mi300x' || hardware === 'mi355x';
+      const isAMD = hardware === 'mi300x' || hardware === 'mi325x' || hardware === 'mi355x';
       const isGB300 = hardware === 'gb300';
-      const effectiveQuant = isAMD ? 'bf16' : (isGB300 && quantization === 'bf16' ? 'fp8' : quantization);
-      const modelSuffix = effectiveQuant === 'fp8' ? '-FP8' : '';
-      const modelName = `${this.modelFamily}/GLM-5.1${modelSuffix}`;
+      const isMXFP4 = quantization === 'mxfp4';
+
+      // Determine effective quantization
+      const effectiveQuant = isGB300 && quantization === 'bf16' ? 'fp8' : quantization;
+
+      // Determine model name and path
+      let modelName;
+      if (isMXFP4) {
+        modelName = 'amd/GLM-5.1-MXFP4';
+      } else {
+        const modelSuffix = effectiveQuant === 'fp8' ? '-FP8' : '';
+        modelName = `${this.modelFamily}/GLM-5.1${modelSuffix}`;
+      }
+
       const hwConfig = this.modelConfigs[hardware][effectiveQuant];
       if (!hwConfig) {
         return '# Configuration not available for the selected hardware and quantization.';
@@ -122,14 +145,26 @@ const GLM51ConfigGenerator = () => {
       }
       cmd += 'sglang serve \\\n';
       cmd += `  --model-path ${modelName}`;
-      cmd += ` \\\n  --tp ${tpValue}`;
+      cmd += ` \\\n  --tensor-parallel-size ${tpValue}`;
+
+      cmd += ' \\\n  --trust-remote-code';
 
       if (isAMD) {
-        cmd += ' \\\n  --trust-remote-code';
-        cmd += ' \\\n  --nsa-prefill-backend tilelang';
-        cmd += ' \\\n  --nsa-decode-backend tilelang';
-        cmd += ' \\\n  --chunked-prefill-size 131072';
-        cmd += ' \\\n  --watchdog-timeout 1200';
+        if (isMXFP4) {
+          // MXFP4-specific flags
+          cmd += ' \\\n  --nsa-prefill-backend tilelang';
+          cmd += ' \\\n  --nsa-decode-backend tilelang';
+          cmd += ' \\\n  --kv-cache-dtype fp8_e4m3';
+          cmd += ' \\\n  --model-loader-extra-config \'{"enable_multithread_load": true, "num_threads": 8}\'';
+          cmd += ' \\\n  --tokenizer-worker-num 4';
+          cmd += ' \\\n  --disable-radix-cache';
+        } else {
+          // BF16-specific flags
+          cmd += ' \\\n  --nsa-prefill-backend tilelang';
+          cmd += ' \\\n  --nsa-decode-backend tilelang';
+          cmd += ' \\\n  --chunked-prefill-size 131072';
+          cmd += ' \\\n  --watchdog-timeout 1200';
+        }
       }
 
       if (values.dpattention === 'enabled') {

--- a/src/components/autoregressive/GLM51ConfigGenerator/index.js
+++ b/src/components/autoregressive/GLM51ConfigGenerator/index.js
@@ -24,11 +24,11 @@ const GLM51ConfigGenerator = () => {
         name: 'hardware',
         title: 'Hardware Platform',
         items: [
-          { id: 'h200', label: 'H200', default: false },
+          { id: 'h200', label: 'H200', default: true },
           { id: 'b200', label: 'B200', default: false },
           { id: 'gb300', label: 'GB300', default: false },
           { id: 'h100', label: 'H100', default: false },
-          { id: 'mi300x', label: 'MI300X', default: true },
+          { id: 'mi300x', label: 'MI300X', default: false },
           { id: 'mi325x', label: 'MI325X', default: false },
           { id: 'mi355x', label: 'MI355X', default: false }
         ]
@@ -67,8 +67,8 @@ const GLM51ConfigGenerator = () => {
         name: 'reasoning',
         title: 'Reasoning Parser',
         items: [
-          { id: 'disabled', label: 'Disabled', default: true },
-          { id: 'enabled', label: 'Enabled', default: false }
+          { id: 'disabled', label: 'Disabled', default: false },
+          { id: 'enabled', label: 'Enabled', default: true }
         ],
         commandRule: (value) => (value === 'enabled' ? '--reasoning-parser glm45' : null)
       },
@@ -76,8 +76,8 @@ const GLM51ConfigGenerator = () => {
         name: 'toolcall',
         title: 'Tool Call Parser',
         items: [
-          { id: 'disabled', label: 'Disabled', default: true },
-          { id: 'enabled', label: 'Enabled', default: false }
+          { id: 'disabled', label: 'Disabled', default: false },
+          { id: 'enabled', label: 'Enabled', default: true }
         ],
         commandRule: (value) => (value === 'enabled' ? '--tool-call-parser glm47' : null)
       },
@@ -93,10 +93,24 @@ const GLM51ConfigGenerator = () => {
       speculative: {
         name: 'speculative',
         title: 'Speculative Decoding (MTP)',
-        items: [
-          { id: 'disabled', label: 'Disabled', default: true },
-          { id: 'enabled', label: 'Enabled', default: false }
-        ],
+        getDynamicItems: (values) => {
+          const hw = values.hardware;
+          const isAMD = hw === 'mi300x' || hw === 'mi325x' || hw === 'mi355x';
+
+          return [
+            {
+              id: 'disabled',
+              label: 'Disabled',
+              default: isAMD ? true : false
+            },
+            {
+              id: 'enabled',
+              label: 'Enabled',
+              default: isAMD ? false : true,
+              disabled: isAMD
+            }
+          ];
+        },
         commandRule: (value) => (value === 'enabled'
           ? '--speculative-algorithm EAGLE \\\n  --speculative-num-steps 3 \\\n  --speculative-eagle-topk 1 \\\n  --speculative-num-draft-tokens 4'
           : null)
@@ -137,6 +151,11 @@ const GLM51ConfigGenerator = () => {
       }
       const tpValue = hwConfig.tp;
       const memFraction = hwConfig.mem;
+
+      // Force speculative to be disabled for AMD (not supported)
+      if (isAMD && values.speculative === 'enabled') {
+        values = { ...values, speculative: 'disabled' };
+      }
       const enableSpec = values.speculative === 'enabled';
 
       let cmd = '';
@@ -147,23 +166,19 @@ const GLM51ConfigGenerator = () => {
       cmd += `  --model-path ${modelName}`;
       cmd += ` \\\n  --tensor-parallel-size ${tpValue}`;
 
-      cmd += ' \\\n  --trust-remote-code';
-
       if (isAMD) {
+        cmd += ' \\\n  --trust-remote-code';
+        cmd += ' \\\n  --model-loader-extra-config \'{"enable_multithread_load": true, "num_threads": 8}\'';
+        cmd += ' \\\n  --chunked-prefill-size 131072';
+        cmd += ' \\\n  --watchdog-timeout 1200';
+        cmd += ` \\\n  --tokenizer-worker-num ${2 * tpValue}`;
+
         if (isMXFP4) {
           // MXFP4-specific flags
           cmd += ' \\\n  --nsa-prefill-backend tilelang';
           cmd += ' \\\n  --nsa-decode-backend tilelang';
-          cmd += ' \\\n  --kv-cache-dtype fp8_e4m3';
-          cmd += ' \\\n  --model-loader-extra-config \'{"enable_multithread_load": true, "num_threads": 8}\'';
-          cmd += ' \\\n  --tokenizer-worker-num 4';
           cmd += ' \\\n  --disable-radix-cache';
-        } else {
-          // BF16-specific flags
-          cmd += ' \\\n  --nsa-prefill-backend tilelang';
-          cmd += ' \\\n  --nsa-decode-backend tilelang';
-          cmd += ' \\\n  --chunked-prefill-size 131072';
-          cmd += ' \\\n  --watchdog-timeout 1200';
+          cmd += ' \\\n  --kv-cache-dtype fp8_e4m3';
         }
       }
 


### PR DESCRIPTION
Add AMD GPU Support with FP8 and FP4 Quantization for GLM-5.1

- **New Model & AMD GPU Support:** Added amd/GLM-5.1-MXFP4 model and enabled FP8/FP4 quantization for AMD MI300X, MI325X, and MI355X GPUs

- **GLM51ConfigGenerator Updates:** Separated AMD hardware options (MI300X/MI325X/MI355X) with FP4 option visible but restricted to MI355X only

- **Documentation Enhancements:** Added FP4 model listing, AMD Docker images section, and updated hardware table with separate BF16/FP8/FP4 TP columns showing support matrix across all GPUs

- **AMD-Specific Optimizations:** Implemented TileLang NSA backend flags for all AMD configs; added MXFP4-specific flags including FP8 KV cache, multithread loading, and disabled radix cache

- **YAML Configuration:** Updated source and generated model configs with AMD hardware defaults and FP4/FP8 support (MI355X: BF16/FP8/FP4, MI325X: BF16/FP8, MI300X: BF16/FP8)