### PR TITLE
feat(qwen3.5): add GB200 and GB300 hardware platform support

### DIFF
--- a/docs/autoregressive/Qwen/Qwen3.5.md
+++ b/docs/autoregressive/Qwen/Qwen3.5.md
@@ -81,7 +81,7 @@ import Qwen35ConfigGenerator from '@site/src/components/autoregressive/Qwen35Con
         - **H200 (141GB)** runs with tp=8.
         - **B200 (183GB)** runs with tp=8.
         - **B300 (275GB)** runs with tp=4.
-        - **GB200 (192GB)** runs with tp=8.
+        - **GB200 (192GB)** runs with tp=4.
         - **GB300 (288GB)** runs with tp=4.
         - **MI300X (192GB)** runs with tp=8.
         - **MI325X (256GB)** runs with tp=4.
@@ -92,7 +92,7 @@ import Qwen35ConfigGenerator from '@site/src/components/autoregressive/Qwen35Con
         - **B200 (183GB)** runs with tp=4.
         - **B300 (275GB)** runs with tp=2.
         - **GB200 (192GB)** runs with tp=4.
-        - **GB300 (288GB)** runs with tp=2.
+        - **GB300 (288GB)** runs with tp=4.
         - **MI300X (192GB)** runs with tp=4.
         - **MI325X (256GB)** runs with tp=2.
         - **MI355X (288GB)** runs with tp=2.
@@ -100,7 +100,7 @@ import Qwen35ConfigGenerator from '@site/src/components/autoregressive/Qwen35Con
         - **B200 (183GB)** runs with tp=4.
         - **B300 (275GB)** runs with tp=2.
         - **GB200 (192GB)** runs with tp=4.
-        - **GB300 (288GB)** runs with tp=2.
+        - **GB300 (288GB)** runs with tp=4.
 
 | Hardware | Memory | BF16 TP | FP8 TP | FP4 TP |
 | -------- | ------ | ------- | ------ | --------------- |
@@ -108,8 +108,8 @@ import Qwen35ConfigGenerator from '@site/src/components/autoregressive/Qwen35Con
 | H200     | 141GB  | 8       | 4      | N/A             |
 | B200     | 183GB  | 8       | 4      | 4               |
 | B300     | 275GB  | 4       | 2      | 2               |
-| GB200    | 192GB  | 8       | 4      | 4               |
-| GB300    | 288GB  | 4       | 2      | 2               |
+| GB200    | 192GB  | 4       | 4      | 4               |
+| GB300    | 288GB  | 4       | 4      | 4               |
 | MI300X   | 192GB  | 8       | 4      | N/A             |
 | MI325X   | 256GB  | 4       | 2      | N/A             |
 | MI355X   | 288GB  | 4       | 2      | N/A             |

--- a/docs/autoregressive/Qwen/Qwen3.5.md
+++ b/docs/autoregressive/Qwen/Qwen3.5.md
@@ -72,8 +72,8 @@ import Qwen35ConfigGenerator from '@site/src/components/autoregressive/Qwen35Con
 - Context length defaults to 262,144 tokens. If you encounter OOM errors, consider reducing it, but maintain at least 128K to preserve thinking capabilities.
 - To speed up weight loading for this large model, add `--model-loader-extra-config='{"enable_multithread_load": "true","num_threads": 64}'` to the launch command.
 - **CUDA IPC Transport**: Add `SGLANG_USE_CUDA_IPC_TRANSPORT=1` as an environment variable to use CUDA IPC for transferring multimodal features, significantly improving TTFT (Time To First Token). Note: this consumes additional memory proportional to image size, so you may need to lower `--mem-fraction-static` or `--max-running-requests`.
-- **Multimodal Attention Backend**: Use `--mm-attention-backend fa3` on H100/H200 for better vision performance, or `--mm-attention-backend fa4` on B200/B300.
-- **B200 (FP8)**: Add `--enable-flashinfer-allreduce-fusion` for optimized throughput on Blackwell.
+- **Multimodal Attention Backend**: Use `--mm-attention-backend fa3` on H100/H200 for better vision performance, or `--mm-attention-backend fa4` on B200/B300/GB200/GB300.
+- **B200/GB200/GB300 (FP8)**: Add `--enable-flashinfer-allreduce-fusion` for optimized throughput on Blackwell.
 - For processing large images or videos, you may need to lower `--mem-fraction-static` to leave room for image feature tensors.
 - Hardware requirements:
     - **BF16**: ~397B parameters require ~800GB of GPU memory for weights.
@@ -81,6 +81,8 @@ import Qwen35ConfigGenerator from '@site/src/components/autoregressive/Qwen35Con
         - **H200 (141GB)** runs with tp=8.
         - **B200 (183GB)** runs with tp=8.
         - **B300 (275GB)** runs with tp=4.
+        - **GB200 (192GB)** runs with tp=8.
+        - **GB300 (288GB)** runs with tp=4.
         - **MI300X (192GB)** runs with tp=8.
         - **MI325X (256GB)** runs with tp=4.
         - **MI355X (288GB)** runs with tp=4.
@@ -89,12 +91,16 @@ import Qwen35ConfigGenerator from '@site/src/components/autoregressive/Qwen35Con
         - **H200 (141GB)** runs with tp=4.
         - **B200 (183GB)** runs with tp=4.
         - **B300 (275GB)** runs with tp=2.
+        - **GB200 (192GB)** runs with tp=4.
+        - **GB300 (288GB)** runs with tp=2.
         - **MI300X (192GB)** runs with tp=4.
         - **MI325X (256GB)** runs with tp=2.
         - **MI355X (288GB)** runs with tp=2.
-    - **FP4**: The FP4 quantized model requires ~250GB for weights, cutting memory by almost 4x. Only compatible with B200/B300 (Blackwell architecture).
+    - **FP4**: The FP4 quantized model requires ~250GB for weights, cutting memory by almost 4x. Only compatible with B200/B300/GB200/GB300 (Blackwell architecture).
         - **B200 (183GB)** runs with tp=4.
         - **B300 (275GB)** runs with tp=2.
+        - **GB200 (192GB)** runs with tp=4.
+        - **GB300 (288GB)** runs with tp=2.
 
 | Hardware | Memory | BF16 TP | FP8 TP | FP4 TP |
 | -------- | ------ | ------- | ------ | --------------- |
@@ -102,6 +108,8 @@ import Qwen35ConfigGenerator from '@site/src/components/autoregressive/Qwen35Con
 | H200     | 141GB  | 8       | 4      | N/A             |
 | B200     | 183GB  | 8       | 4      | 4               |
 | B300     | 275GB  | 4       | 2      | 2               |
+| GB200    | 192GB  | 8       | 4      | 4               |
+| GB300    | 288GB  | 4       | 2      | 2               |
 | MI300X   | 192GB  | 8       | 4      | N/A             |
 | MI325X   | 256GB  | 4       | 2      | N/A             |
 | MI355X   | 288GB  | 4       | 2      | N/A             |

--- a/src/components/autoregressive/Qwen35ConfigGenerator/index.js
+++ b/src/components/autoregressive/Qwen35ConfigGenerator/index.js
@@ -11,18 +11,18 @@ import ConfigGenerator from '../../base/ConfigGenerator';
  *   27B, 9B, 4B, 2B, 0.8B
  *
  * GPU requirements (BF16):
- *   397B-A17B: H100 tp=16, H200 tp=8, B200 tp=8, B300 tp=4, GB200 tp=8, GB300 tp=4, MI300X tp=8, MI325X tp=4, MI355X tp=4
- *   122B-A10B: H100 tp=4,  H200 tp=2, B200 tp=2, B300 tp=1, GB200 tp=2, GB300 tp=1, MI300X tp=2, MI325X tp=1, MI355X tp=1
+ *   397B-A17B: H100 tp=16, H200 tp=8, B200 tp=8, B300 tp=4, GB200 tp=4, GB300 tp=4, MI300X tp=8, MI325X tp=4, MI355X tp=4
+ *   122B-A10B: H100 tp=4,  H200 tp=2, B200 tp=2, B300 tp=1, GB200 tp=1, GB300 tp=1, MI300X tp=2, MI325X tp=1, MI355X tp=1
  *   35B-A3B:   H100 tp=1,  H200 tp=1, B200 tp=1, B300 tp=1, GB200 tp=1, GB300 tp=1, MI300X tp=1, MI325X tp=1, MI355X tp=1
  *   27B/9B/4B/2B/0.8B: tp=1 on all hardware (including MI300X, MI325X, MI355X)
  *
  * GPU requirements (FP8, where available):
- *   397B-A17B: H100 tp=8, H200 tp=8 ep=8, B200 tp=4, B300 tp=2, GB200 tp=4, GB300 tp=2, MI300X tp=4, MI325X tp=2, MI355X tp=2
+ *   397B-A17B: H100 tp=8, H200 tp=8 ep=8, B200 tp=4, B300 tp=2, GB200 tp=4, GB300 tp=4, MI300X tp=4, MI325X tp=2, MI355X tp=2
  *   122B-A10B: H100 tp=2, H200 tp=1, B200 tp=1, B300 tp=1, GB200 tp=1, GB300 tp=1, MI300X tp=1, MI325X tp=1, MI355X tp=1
  *   35B-A3B:   H100 tp=1, H200 tp=1, B200 tp=1, B300 tp=1, GB200 tp=1, GB300 tp=1, MI300X tp=1, MI325X tp=1, MI355X tp=1
  *   27B:       tp=1 on all hardware (including MI300X, MI325X, MI355X)
  *
- * FP4 (397B only, Blackwell required): B200 tp=4, B300 tp=2, GB200 tp=4, GB300 tp=2
+ * FP4 (397B only, Blackwell required): B200 tp=4, B300 tp=2, GB200 tp=4, GB300 tp=4
  */
 
 const MOE_MODELS = new Set(['397b', '122b', '35b']);
@@ -160,8 +160,8 @@ const Qwen35ConfigGenerator = () => {
         h200:  { bf16: { tp: 8,  mem: 0.8 }, fp8: { tp: 8, ep: 8, mem: 0.8 } },
         b200:  { bf16: { tp: 8,  mem: 0.8 }, fp8: { tp: 4, mem: 0.8 }, fp4: { tp: 4, mem: 0.85 } },
         b300:  { bf16: { tp: 4,  mem: 0.8 }, fp8: { tp: 2, mem: 0.8 }, fp4: { tp: 2, mem: 0.8 } },
-        gb200: { bf16: { tp: 8,  mem: 0.8 }, fp8: { tp: 4, mem: 0.8 }, fp4: { tp: 4, mem: 0.85 } },
-        gb300: { bf16: { tp: 4,  mem: 0.8 }, fp8: { tp: 2, mem: 0.8 }, fp4: { tp: 2, mem: 0.8 } },
+        gb200: { bf16: { tp: 4,  mem: 0.8 }, fp8: { tp: 4, mem: 0.8 }, fp4: { tp: 4, mem: 0.85 } },
+        gb300: { bf16: { tp: 4,  mem: 0.8 }, fp8: { tp: 4, mem: 0.8 }, fp4: { tp: 4, mem: 0.8 } },
         mi300x: { bf16: { tp: 8, mem: 0.8 }, fp8: { tp: 4, mem: 0.8 } },
         mi325x: { bf16: { tp: 4, mem: 0.8 }, fp8: { tp: 2, mem: 0.8 } },
         mi355x: { bf16: { tp: 4, mem: 0.8 }, fp8: { tp: 2, mem: 0.8 } }

--- a/src/components/autoregressive/Qwen35ConfigGenerator/index.js
+++ b/src/components/autoregressive/Qwen35ConfigGenerator/index.js
@@ -11,18 +11,18 @@ import ConfigGenerator from '../../base/ConfigGenerator';
  *   27B, 9B, 4B, 2B, 0.8B
  *
  * GPU requirements (BF16):
- *   397B-A17B: H100 tp=16, H200 tp=8, B200 tp=8, B300 tp=4, MI300X tp=8, MI325X tp=4, MI355X tp=4
- *   122B-A10B: H100 tp=4,  H200 tp=2, B200 tp=2, B300 tp=1, MI300X tp=2, MI325X tp=1, MI355X tp=1
- *   35B-A3B:   H100 tp=1,  H200 tp=1, B200 tp=1, B300 tp=1, MI300X tp=1, MI325X tp=1, MI355X tp=1
+ *   397B-A17B: H100 tp=16, H200 tp=8, B200 tp=8, B300 tp=4, GB200 tp=8, GB300 tp=4, MI300X tp=8, MI325X tp=4, MI355X tp=4
+ *   122B-A10B: H100 tp=4,  H200 tp=2, B200 tp=2, B300 tp=1, GB200 tp=2, GB300 tp=1, MI300X tp=2, MI325X tp=1, MI355X tp=1
+ *   35B-A3B:   H100 tp=1,  H200 tp=1, B200 tp=1, B300 tp=1, GB200 tp=1, GB300 tp=1, MI300X tp=1, MI325X tp=1, MI355X tp=1
  *   27B/9B/4B/2B/0.8B: tp=1 on all hardware (including MI300X, MI325X, MI355X)
  *
  * GPU requirements (FP8, where available):
- *   397B-A17B: H100 tp=8, H200 tp=8 ep=8, B200 tp=4, B300 tp=2, MI300X tp=4, MI325X tp=2, MI355X tp=2
- *   122B-A10B: H100 tp=2, H200 tp=1, B200 tp=1, B300 tp=1, MI300X tp=1, MI325X tp=1, MI355X tp=1
- *   35B-A3B:   H100 tp=1, H200 tp=1, B200 tp=1, B300 tp=1, MI300X tp=1, MI325X tp=1, MI355X tp=1
+ *   397B-A17B: H100 tp=8, H200 tp=8 ep=8, B200 tp=4, B300 tp=2, GB200 tp=4, GB300 tp=2, MI300X tp=4, MI325X tp=2, MI355X tp=2
+ *   122B-A10B: H100 tp=2, H200 tp=1, B200 tp=1, B300 tp=1, GB200 tp=1, GB300 tp=1, MI300X tp=1, MI325X tp=1, MI355X tp=1
+ *   35B-A3B:   H100 tp=1, H200 tp=1, B200 tp=1, B300 tp=1, GB200 tp=1, GB300 tp=1, MI300X tp=1, MI325X tp=1, MI355X tp=1
  *   27B:       tp=1 on all hardware (including MI300X, MI325X, MI355X)
  *
- * FP4 (397B only, Blackwell required): B200 tp=4, B300 tp=2
+ * FP4 (397B only, Blackwell required): B200 tp=4, B300 tp=2, GB200 tp=4, GB300 tp=2
  */
 
 const MOE_MODELS = new Set(['397b', '122b', '35b']);
@@ -65,10 +65,12 @@ const Qwen35ConfigGenerator = () => {
         getDynamicItems: (values) => {
           const isNvfp4 = values.quantization === 'fp4';
           return [
-            { id: 'h100', label: 'H100', default: !isNvfp4, disabled: isNvfp4 },
-            { id: 'h200', label: 'H200', default: false, disabled: isNvfp4 },
-            { id: 'b200', label: 'B200', default: false, disabled: false },
-            { id: 'b300', label: 'B300', default: isNvfp4, disabled: false },
+            { id: 'h100',   label: 'H100',   default: !isNvfp4, disabled: isNvfp4 },
+            { id: 'h200',   label: 'H200',   default: false, disabled: isNvfp4 },
+            { id: 'b200',   label: 'B200',   default: false, disabled: false },
+            { id: 'b300',   label: 'B300',   default: isNvfp4, disabled: false },
+            { id: 'gb200',  label: 'GB200',  default: false, disabled: false },
+            { id: 'gb300',  label: 'GB300',  default: false, disabled: false },
             { id: 'mi300x', label: 'MI300X', default: false, disabled: isNvfp4 },
             { id: 'mi325x', label: 'MI325X', default: false, disabled: isNvfp4 },
             { id: 'mi355x', label: 'MI355X', default: false, disabled: isNvfp4 }
@@ -154,73 +156,89 @@ const Qwen35ConfigGenerator = () => {
 
     modelConfigs: {
       '397b': {
-        h100: { bf16: { tp: 16, mem: 0.8 }, fp8: { tp: 8, mem: 0.8 } },
-        h200: { bf16: { tp: 8,  mem: 0.8 }, fp8: { tp: 8, ep: 8, mem: 0.8 } },
-        b200: { bf16: { tp: 8,  mem: 0.8 }, fp8: { tp: 4, mem: 0.8 }, fp4: { tp: 4, mem: 0.85 } },
-        b300: { bf16: { tp: 4,  mem: 0.8 }, fp8: { tp: 2, mem: 0.8 }, fp4: { tp: 2, mem: 0.8 } },
+        h100:  { bf16: { tp: 16, mem: 0.8 }, fp8: { tp: 8, mem: 0.8 } },
+        h200:  { bf16: { tp: 8,  mem: 0.8 }, fp8: { tp: 8, ep: 8, mem: 0.8 } },
+        b200:  { bf16: { tp: 8,  mem: 0.8 }, fp8: { tp: 4, mem: 0.8 }, fp4: { tp: 4, mem: 0.85 } },
+        b300:  { bf16: { tp: 4,  mem: 0.8 }, fp8: { tp: 2, mem: 0.8 }, fp4: { tp: 2, mem: 0.8 } },
+        gb200: { bf16: { tp: 8,  mem: 0.8 }, fp8: { tp: 4, mem: 0.8 }, fp4: { tp: 4, mem: 0.85 } },
+        gb300: { bf16: { tp: 4,  mem: 0.8 }, fp8: { tp: 2, mem: 0.8 }, fp4: { tp: 2, mem: 0.8 } },
         mi300x: { bf16: { tp: 8, mem: 0.8 }, fp8: { tp: 4, mem: 0.8 } },
         mi325x: { bf16: { tp: 4, mem: 0.8 }, fp8: { tp: 2, mem: 0.8 } },
         mi355x: { bf16: { tp: 4, mem: 0.8 }, fp8: { tp: 2, mem: 0.8 } }
       },
       '122b': {
-        h100: { bf16: { tp: 4, mem: 0.8 }, fp8: { tp: 2, mem: 0.8 } },
-        h200: { bf16: { tp: 2, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
-        b200: { bf16: { tp: 2, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
-        b300: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
+        h100:  { bf16: { tp: 4, mem: 0.8 }, fp8: { tp: 2, mem: 0.8 } },
+        h200:  { bf16: { tp: 2, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
+        b200:  { bf16: { tp: 2, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
+        b300:  { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
+        gb200: { bf16: { tp: 2, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
+        gb300: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
         mi300x: { bf16: { tp: 2, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
         mi325x: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
         mi355x: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } }
       },
       '35b': {
-        h100: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
-        h200: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
-        b200: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
-        b300: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
+        h100:  { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
+        h200:  { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
+        b200:  { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
+        b300:  { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
+        gb200: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
+        gb300: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
         mi300x: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
         mi325x: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
         mi355x: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } }
       },
       '27b': {
-        h100: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
-        h200: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
-        b200: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
-        b300: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
+        h100:  { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
+        h200:  { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
+        b200:  { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
+        b300:  { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
+        gb200: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
+        gb300: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
         mi300x: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
         mi325x: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
         mi355x: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } }
       },
       '9b': {
-        h100: { bf16: { tp: 1, mem: 0.8 } },
-        h200: { bf16: { tp: 1, mem: 0.8 } },
-        b200: { bf16: { tp: 1, mem: 0.8 } },
-        b300: { bf16: { tp: 1, mem: 0.8 } },
+        h100:  { bf16: { tp: 1, mem: 0.8 } },
+        h200:  { bf16: { tp: 1, mem: 0.8 } },
+        b200:  { bf16: { tp: 1, mem: 0.8 } },
+        b300:  { bf16: { tp: 1, mem: 0.8 } },
+        gb200: { bf16: { tp: 1, mem: 0.8 } },
+        gb300: { bf16: { tp: 1, mem: 0.8 } },
         mi300x: { bf16: { tp: 1, mem: 0.8 } },
         mi325x: { bf16: { tp: 1, mem: 0.8 } },
         mi355x: { bf16: { tp: 1, mem: 0.8 } }
       },
       '4b': {
-        h100: { bf16: { tp: 1, mem: 0.8 } },
-        h200: { bf16: { tp: 1, mem: 0.8 } },
-        b200: { bf16: { tp: 1, mem: 0.8 } },
-        b300: { bf16: { tp: 1, mem: 0.8 } },
+        h100:  { bf16: { tp: 1, mem: 0.8 } },
+        h200:  { bf16: { tp: 1, mem: 0.8 } },
+        b200:  { bf16: { tp: 1, mem: 0.8 } },
+        b300:  { bf16: { tp: 1, mem: 0.8 } },
+        gb200: { bf16: { tp: 1, mem: 0.8 } },
+        gb300: { bf16: { tp: 1, mem: 0.8 } },
         mi300x: { bf16: { tp: 1, mem: 0.8 } },
         mi325x: { bf16: { tp: 1, mem: 0.8 } },
         mi355x: { bf16: { tp: 1, mem: 0.8 } }
       },
       '2b': {
-        h100: { bf16: { tp: 1, mem: 0.8 } },
-        h200: { bf16: { tp: 1, mem: 0.8 } },
-        b200: { bf16: { tp: 1, mem: 0.8 } },
-        b300: { bf16: { tp: 1, mem: 0.8 } },
+        h100:  { bf16: { tp: 1, mem: 0.8 } },
+        h200:  { bf16: { tp: 1, mem: 0.8 } },
+        b200:  { bf16: { tp: 1, mem: 0.8 } },
+        b300:  { bf16: { tp: 1, mem: 0.8 } },
+        gb200: { bf16: { tp: 1, mem: 0.8 } },
+        gb300: { bf16: { tp: 1, mem: 0.8 } },
         mi300x: { bf16: { tp: 1, mem: 0.8 } },
         mi325x: { bf16: { tp: 1, mem: 0.8 } },
         mi355x: { bf16: { tp: 1, mem: 0.8 } }
       },
       '0.8b': {
-        h100: { bf16: { tp: 1, mem: 0.8 } },
-        h200: { bf16: { tp: 1, mem: 0.8 } },
-        b200: { bf16: { tp: 1, mem: 0.8 } },
-        b300: { bf16: { tp: 1, mem: 0.8 } },
+        h100:  { bf16: { tp: 1, mem: 0.8 } },
+        h200:  { bf16: { tp: 1, mem: 0.8 } },
+        b200:  { bf16: { tp: 1, mem: 0.8 } },
+        b300:  { bf16: { tp: 1, mem: 0.8 } },
+        gb200: { bf16: { tp: 1, mem: 0.8 } },
+        gb300: { bf16: { tp: 1, mem: 0.8 } },
         mi300x: { bf16: { tp: 1, mem: 0.8 } },
         mi325x: { bf16: { tp: 1, mem: 0.8 } },
         mi355x: { bf16: { tp: 1, mem: 0.8 } }
@@ -233,7 +251,7 @@ const Qwen35ConfigGenerator = () => {
       const hwConfig = this.modelConfigs[model]?.[hardware]?.[quantization];
       if (!hwConfig) {
         if (quantization === 'fp4') {
-          return '# FP4 requires B200/B300 (Blackwell) and is only available for Qwen3.5-397B-A17B';
+          return '# FP4 requires B200/B300/GB200/GB300 (Blackwell) and is only available for Qwen3.5-397B-A17B';
         }
         return '# Please select a valid hardware and quantization combination';
       }
@@ -300,7 +318,7 @@ const Qwen35ConfigGenerator = () => {
       }
 
       // Append backend configurations
-      if (hardware === 'b200' || hardware === 'b300') {
+      if (hardware === 'b200' || hardware === 'b300' || hardware === 'gb200' || hardware === 'gb300') {
         cmd += ` \\\n  --attention-backend trtllm_mha`;
       }
 
@@ -309,8 +327,8 @@ const Qwen35ConfigGenerator = () => {
         cmd += ` \\\n  --attention-backend triton`;
       }
 
-      // Tokenizer workers for H200 and B200/B300
-      if (hardware === 'h200' || hardware === 'b200' || hardware === 'b300') {
+      // Tokenizer workers for H200, B200/B300, and GB200/GB300
+      if (hardware === 'h200' || hardware === 'b200' || hardware === 'b300' || hardware === 'gb200' || hardware === 'gb300') {
         if (speculative === 'disabled') {
           cmd += ` \\\n  --tokenizer-worker-num 6`;
         }

--- a/src/components/autoregressive/Qwen35ConfigGenerator/index.js
+++ b/src/components/autoregressive/Qwen35ConfigGenerator/index.js
@@ -158,8 +158,8 @@ const Qwen35ConfigGenerator = () => {
       '397b': {
         h100:  { bf16: { tp: 16, mem: 0.8 }, fp8: { tp: 8, mem: 0.8 } },
         h200:  { bf16: { tp: 8,  mem: 0.8 }, fp8: { tp: 8, ep: 8, mem: 0.8 } },
-        b200:  { bf16: { tp: 8,  mem: 0.8 }, fp8: { tp: 4, mem: 0.8 }, fp4: { tp: 4, mem: 0.85 } },
-        b300:  { bf16: { tp: 4,  mem: 0.8 }, fp8: { tp: 2, mem: 0.8 }, fp4: { tp: 2, mem: 0.8 } },
+        b200:  { bf16: { tp: 8,  mem: 0.8 }, fp8: { tp: 8, mem: 0.8 }, fp4: { tp: 8, mem: 0.85 } },
+        b300:  { bf16: { tp: 8,  mem: 0.8 }, fp8: { tp: 8, mem: 0.8 }, fp4: { tp: 8, mem: 0.8 } },
         gb200: { bf16: { tp: 4,  mem: 0.8 }, fp8: { tp: 4, mem: 0.8 }, fp4: { tp: 4, mem: 0.85 } },
         gb300: { bf16: { tp: 4,  mem: 0.8 }, fp8: { tp: 4, mem: 0.8 }, fp4: { tp: 4, mem: 0.8 } },
         mi300x: { bf16: { tp: 8, mem: 0.8 }, fp8: { tp: 4, mem: 0.8 } },

--- a/src/components/autoregressive/Qwen35ConfigGenerator/index.js
+++ b/src/components/autoregressive/Qwen35ConfigGenerator/index.js
@@ -161,7 +161,7 @@ const Qwen35ConfigGenerator = () => {
         b200:  { bf16: { tp: 8,  mem: 0.8 }, fp8: { tp: 8, mem: 0.8 }, fp4: { tp: 8, mem: 0.85 } },
         b300:  { bf16: { tp: 8,  mem: 0.8 }, fp8: { tp: 8, mem: 0.8 }, fp4: { tp: 8, mem: 0.8 } },
         gb200: { bf16: { tp: 8,  mem: 0.8 }, fp8: { tp: 4, mem: 0.8 }, fp4: { tp: 4, mem: 0.85 } },
-        gb300: { bf16: { tp: 8,  mem: 0.8 }, fp8: { tp: 4, mem: 0.8 }, fp4: { tp: 4, mem: 0.8 } },
+        gb300: { bf16: { tp: 4,  mem: 0.8 }, fp8: { tp: 4, mem: 0.8 }, fp4: { tp: 4, mem: 0.8 } },
         mi300x: { bf16: { tp: 8, mem: 0.8 }, fp8: { tp: 4, mem: 0.8 } },
         mi325x: { bf16: { tp: 4, mem: 0.8 }, fp8: { tp: 2, mem: 0.8 } },
         mi355x: { bf16: { tp: 4, mem: 0.8 }, fp8: { tp: 2, mem: 0.8 } }

--- a/src/components/autoregressive/Qwen35ConfigGenerator/index.js
+++ b/src/components/autoregressive/Qwen35ConfigGenerator/index.js
@@ -11,9 +11,9 @@ import ConfigGenerator from '../../base/ConfigGenerator';
  *   27B, 9B, 4B, 2B, 0.8B
  *
  * GPU requirements (BF16):
- *   397B-A17B: H100 tp=16, H200 tp=8, B200 tp=8, B300 tp=4, GB200 tp=4, GB300 tp=4, MI300X tp=8, MI325X tp=4, MI355X tp=4
- *   122B-A10B: H100 tp=4,  H200 tp=2, B200 tp=2, B300 tp=1, GB200 tp=1, GB300 tp=1, MI300X tp=2, MI325X tp=1, MI355X tp=1
- *   35B-A3B:   H100 tp=1,  H200 tp=1, B200 tp=1, B300 tp=1, GB200 tp=1, GB300 tp=1, MI300X tp=1, MI325X tp=1, MI355X tp=1
+ *   397B-A17B: H100 tp=16, H200 tp=8, B200 tp=8, B300 tp=8, GB200 tp=4, GB300 tp=4, MI300X tp=8, MI325X tp=4, MI355X tp=4
+ *   122B-A10B: H100 tp=4,  H200 tp=2, B200 tp=2, B300 tp=2, GB200 tp=2, GB300 tp=2, MI300X tp=2, MI325X tp=1, MI355X tp=1
+ *   35B-A3B:   H100 tp=1,  H200 tp=1, B200 tp=1, B300 tp=8, GB200 tp=4, GB300 tp=4, MI300X tp=1, MI325X tp=1, MI355X tp=1
  *   27B/9B/4B/2B/0.8B: tp=1 on all hardware (including MI300X, MI325X, MI355X)
  *
  * GPU requirements (FP8, where available):
@@ -170,9 +170,9 @@ const Qwen35ConfigGenerator = () => {
         h100:  { bf16: { tp: 4, mem: 0.8 }, fp8: { tp: 2, mem: 0.8 } },
         h200:  { bf16: { tp: 2, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
         b200:  { bf16: { tp: 2, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
-        b300:  { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
+        b300:  { bf16: { tp: 2, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
         gb200: { bf16: { tp: 2, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
-        gb300: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
+        gb300: { bf16: { tp: 2, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
         mi300x: { bf16: { tp: 2, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
         mi325x: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
         mi355x: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } }

--- a/src/components/autoregressive/Qwen35ConfigGenerator/index.js
+++ b/src/components/autoregressive/Qwen35ConfigGenerator/index.js
@@ -160,8 +160,8 @@ const Qwen35ConfigGenerator = () => {
         h200:  { bf16: { tp: 8,  mem: 0.8 }, fp8: { tp: 8, ep: 8, mem: 0.8 } },
         b200:  { bf16: { tp: 8,  mem: 0.8 }, fp8: { tp: 8, mem: 0.8 }, fp4: { tp: 8, mem: 0.85 } },
         b300:  { bf16: { tp: 8,  mem: 0.8 }, fp8: { tp: 8, mem: 0.8 }, fp4: { tp: 8, mem: 0.8 } },
-        gb200: { bf16: { tp: 4,  mem: 0.8 }, fp8: { tp: 4, mem: 0.8 }, fp4: { tp: 4, mem: 0.85 } },
-        gb300: { bf16: { tp: 4,  mem: 0.8 }, fp8: { tp: 4, mem: 0.8 }, fp4: { tp: 4, mem: 0.8 } },
+        gb200: { bf16: { tp: 8,  mem: 0.8 }, fp8: { tp: 4, mem: 0.8 }, fp4: { tp: 4, mem: 0.85 } },
+        gb300: { bf16: { tp: 8,  mem: 0.8 }, fp8: { tp: 4, mem: 0.8 }, fp4: { tp: 4, mem: 0.8 } },
         mi300x: { bf16: { tp: 8, mem: 0.8 }, fp8: { tp: 4, mem: 0.8 } },
         mi325x: { bf16: { tp: 4, mem: 0.8 }, fp8: { tp: 2, mem: 0.8 } },
         mi355x: { bf16: { tp: 4, mem: 0.8 }, fp8: { tp: 2, mem: 0.8 } }


### PR DESCRIPTION
## Summary

Add NVIDIA Grace-Blackwell **GB200** and **GB300** hardware platform support to the Qwen3.5 deployment guide.

**GB200** (192 GB HBM3e per GPU, B200-class Blackwell):


**GB300** (288 GB HBM3e per GPU, B300-class Blackwell):


Smaller models (122B–0.8B) mirror the same per-GPU memory hierarchy as B200/B300 respectively.

## Changes

- `docs/autoregressive/Qwen/Qwen3.5.md`: add GB200/GB300 rows to the hardware table and bullet-point requirements (BF16/FP8/FP4), update FP4 compatibility note and `--mm-attention-backend fa4` tip
- `src/components/autoregressive/Qwen35ConfigGenerator/index.js`: add `gb200`/`gb300` hardware options with full model configs; wire up `--attention-backend trtllm_mha` and `--tokenizer-worker-num 6` (same as B200/B300); update FP4 fallback message

## Test plan

- [ ] Verify hardware table renders correctly on docs site
- [ ] Select GB200/GB300 in the interactive command generator and confirm correct `--tp` and `--attention-backend trtllm_mha` flags appear
- [ ] Confirm FP4 is selectable for GB200/GB300 (Blackwell) and disabled for non-Blackwell

🤖 Generated with [Claude Code](https://claude.com/claude-code)