### PR TITLE
Update Qwen3.5 B200 FP4 SGLang recipe

### DIFF
--- a/docs/autoregressive/Qwen/Qwen3.5.md
+++ b/docs/autoregressive/Qwen/Qwen3.5.md
@@ -93,14 +93,14 @@ import Qwen35ConfigGenerator from '@site/src/components/autoregressive/Qwen35Con
         - **MI325X (256GB)** runs with tp=2.
         - **MI355X (288GB)** runs with tp=2.
     - **FP4**: The FP4 quantized model requires ~250GB for weights, cutting memory by almost 4x. Only compatible with B200/B300 (Blackwell architecture).
-        - **B200 (183GB)** runs with tp=4.
+        - **B200 (183GB)** runs with tp=2.
         - **B300 (275GB)** runs with tp=2.
 
 | Hardware | Memory | BF16 TP | FP8 TP | FP4 TP |
 | -------- | ------ | ------- | ------ | --------------- |
 | H100     | 80GB   | 16      | 8      | N/A             |
 | H200     | 141GB  | 8       | 4      | N/A             |
-| B200     | 183GB  | 8       | 4      | 4               |
+| B200     | 183GB  | 8       | 4      | 2               |
 | B300     | 275GB  | 4       | 2      | 2               |
 | MI300X   | 192GB  | 8       | 4      | N/A             |
 | MI325X   | 256GB  | 4       | 2      | N/A             |

--- a/src/components/autoregressive/Qwen35ConfigGenerator/index.js
+++ b/src/components/autoregressive/Qwen35ConfigGenerator/index.js
@@ -22,7 +22,7 @@ import ConfigGenerator from '../../base/ConfigGenerator';
  *   35B-A3B:   H100 tp=1, H200 tp=1, B200 tp=1, B300 tp=1, MI300X tp=1, MI325X tp=1, MI355X tp=1
  *   27B:       tp=1 on all hardware (including MI300X, MI325X, MI355X)
  *
- * FP4 (397B only, Blackwell required): B200 tp=4, B300 tp=2
+ * FP4 (397B only, Blackwell required): B200 tp=2, B300 tp=2
  */
 
 const MOE_MODELS = new Set(['397b', '122b', '35b']);
@@ -156,7 +156,7 @@ const Qwen35ConfigGenerator = () => {
       '397b': {
         h100: { bf16: { tp: 16, mem: 0.8 }, fp8: { tp: 8, mem: 0.8 } },
         h200: { bf16: { tp: 8,  mem: 0.8 }, fp8: { tp: 8, ep: 8, mem: 0.8 } },
-        b200: { bf16: { tp: 8,  mem: 0.8 }, fp8: { tp: 4, mem: 0.8 }, fp4: { tp: 4, mem: 0.85 } },
+        b200: { bf16: { tp: 8,  mem: 0.8 }, fp8: { tp: 4, mem: 0.8 }, fp4: { tp: 2, mem: 0.8 } },
         b300: { bf16: { tp: 4,  mem: 0.8 }, fp8: { tp: 2, mem: 0.8 }, fp4: { tp: 2, mem: 0.8 } },
         mi300x: { bf16: { tp: 8, mem: 0.8 }, fp8: { tp: 4, mem: 0.8 } },
         mi325x: { bf16: { tp: 4, mem: 0.8 }, fp8: { tp: 2, mem: 0.8 } },
@@ -316,17 +316,22 @@ const Qwen35ConfigGenerator = () => {
         }
       }
 
-      // FP4-specific backend settings
+      // FP4-specific backend settings (B200 validated in InferenceX#1018)
       if (quantization === 'fp4') {
+        cmd += ' \\\n  --enable-symm-mem';
         cmd += ' \\\n  --quantization modelopt_fp4';
-        cmd += ' \\\n  --fp4-gemm-backend flashinfer_cutlass';
         cmd += ' \\\n  --kv-cache-dtype fp8_e4m3';
+        if (MOE_MODELS.has(model)) {
+          cmd += ' \\\n  --mamba-ssm-dtype bfloat16';
+        }
         cmd += ' \\\n  --moe-runner-backend flashinfer_trtllm';
-        cmd += ' \\\n  --chunked-prefill-size 32768';
-        cmd += ' \\\n  --max-prefill-tokens 32768';
-        cmd += ' \\\n  --max-running-requests 128';
-        cmd += ' \\\n  --stream-interval 30';
+        cmd += ' \\\n  --chunked-prefill-size 16384';
+        cmd += ' \\\n  --max-prefill-tokens 16384';
+        cmd += ' \\\n  --stream-interval 50';
         cmd += ' \\\n  --disable-radix-cache';
+        if (speculative === 'enabled') {
+          cmd += ' \\\n  --tokenizer-worker-num 6';
+        }
       }
 
       // Add memory fraction last


### PR DESCRIPTION
Update the Qwen3.5 B200 FP4 SGLang recipe to match the latest validated benchmark — switch B200 FP4 to tp=2 mem=0.8, drop --fp4-gemm-backend and --max-running-requests, add --enable-symm-mem and --mamba-ssm-dtype bfloat16, lower prefill/chunked sizes to 16384, and bump --stream-interval to 50. Based on SemiAnalysisAI/InferenceX#1018.