### PR TITLE
Update Qwen3.5 B200 FP4 MTP SGLang recipe

### DIFF
--- a/docs/autoregressive/Qwen/Qwen3.5.md
+++ b/docs/autoregressive/Qwen/Qwen3.5.md
@@ -92,14 +92,14 @@ import Qwen35ConfigGenerator from '@site/src/components/autoregressive/Qwen35Con
         - **MI325X (256GB)** runs with tp=2.
         - **MI355X (288GB)** runs with tp=2.
     - **FP4**: The FP4 quantized model requires ~250GB for weights, cutting memory by almost 4x. Only compatible with B200/B300 (Blackwell architecture).
-        - **B200 (183GB)** runs with tp=4.
+        - **B200 (183GB)** runs with tp=2.
         - **B300 (275GB)** runs with tp=2.
 
 | Hardware | Memory | BF16 TP | FP8 TP | FP4 TP |
 | -------- | ------ | ------- | ------ | --------------- |
 | H100     | 80GB   | 16      | 8      | N/A             |
 | H200     | 141GB  | 8       | 4      | N/A             |
-| B200     | 183GB  | 8       | 4      | 4               |
+| B200     | 183GB  | 8       | 4      | 2               |
 | B300     | 275GB  | 4       | 2      | 2               |
 | MI300X   | 192GB  | 8       | 4      | N/A             |
 | MI325X   | 256GB  | 4       | 2      | N/A             |

--- a/docs/autoregressive/Qwen/Qwen3.5.md
+++ b/docs/autoregressive/Qwen/Qwen3.5.md
@@ -73,7 +73,6 @@ import Qwen35ConfigGenerator from '@site/src/components/autoregressive/Qwen35Con
 - To speed up weight loading for this large model, add `--model-loader-extra-config='{"enable_multithread_load": "true","num_threads": 64}'` to the launch command.
 - **CUDA IPC Transport**: Add `SGLANG_USE_CUDA_IPC_TRANSPORT=1` as an environment variable to use CUDA IPC for transferring multimodal features, significantly improving TTFT (Time To First Token). Note: this consumes additional memory proportional to image size, so you may need to lower `--mem-fraction-static` or `--max-running-requests`.
 - **Multimodal Attention Backend**: Use `--mm-attention-backend fa3` on H100/H200 for better vision performance, or `--mm-attention-backend fa4` on B200/B300.
-- **B200 (FP8)**: Add `--enable-flashinfer-allreduce-fusion` for optimized throughput on Blackwell.
 - For processing large images or videos, you may need to lower `--mem-fraction-static` to leave room for image feature tensors.
 - Hardware requirements:
     - **BF16**: ~397B parameters require ~800GB of GPU memory for weights.

--- a/docs/autoregressive/Qwen/Qwen3.5.md
+++ b/docs/autoregressive/Qwen/Qwen3.5.md
@@ -73,6 +73,8 @@ import Qwen35ConfigGenerator from '@site/src/components/autoregressive/Qwen35Con
 - To speed up weight loading for this large model, add `--model-loader-extra-config='{"enable_multithread_load": "true","num_threads": 64}'` to the launch command.
 - **CUDA IPC Transport**: Add `SGLANG_USE_CUDA_IPC_TRANSPORT=1` as an environment variable to use CUDA IPC for transferring multimodal features, significantly improving TTFT (Time To First Token). Note: this consumes additional memory proportional to image size, so you may need to lower `--mem-fraction-static` or `--max-running-requests`.
 - **Multimodal Attention Backend**: Use `--mm-attention-backend fa3` on H100/H200 for better vision performance, or `--mm-attention-backend fa4` on B200/B300.
+- **B200 (FP8)**: Add `--enable-flashinfer-allreduce-fusion` for optimized throughput on Blackwell.
+
 - For processing large images or videos, you may need to lower `--mem-fraction-static` to leave room for image feature tensors.
 - Hardware requirements:
     - **BF16**: ~397B parameters require ~800GB of GPU memory for weights.

--- a/src/components/autoregressive/Qwen35ConfigGenerator/index.js
+++ b/src/components/autoregressive/Qwen35ConfigGenerator/index.js
@@ -286,8 +286,8 @@ const Qwen35ConfigGenerator = () => {
         cmd += ` \\\n  --tokenizer-worker-num 6`;
       }
 
-      // Enable allreduce fusion for all Qwen3.5 configs (skip for FP4: benchmark only enables this for TP≥8).
-      if (quantization !== 'fp4') {
+      // Enable allreduce fusion for all Qwen3.5 configs (skip for FP4 and B200 FP8: benchmark does not enable it).
+      if (quantization !== 'fp4' && !(hardware === 'b200' && quantization === 'fp8')) {
         cmd += ` \\\n  --enable-flashinfer-allreduce-fusion`;
       }
 
@@ -297,6 +297,19 @@ const Qwen35ConfigGenerator = () => {
         if (MOE_MODELS.has(model)) {
           cmd += ` \\\n  --mamba-ssm-dtype bfloat16`;
         }
+      }
+
+      // B200 FP8-specific optimizations (validated in InferenceX#1027)
+      if (hardware === 'b200' && quantization === 'fp8') {
+        cmd += ` \\\n  --enable-symm-mem`;
+        cmd += ` \\\n  --disable-radix-cache`;
+        if (MOE_MODELS.has(model)) {
+          cmd += ` \\\n  --mamba-ssm-dtype bfloat16`;
+        }
+        cmd += ` \\\n  --moe-runner-backend flashinfer_trtllm`;
+        cmd += ` \\\n  --chunked-prefill-size 16384`;
+        cmd += ` \\\n  --max-prefill-tokens 16384`;
+        cmd += ` \\\n  --stream-interval 50`;
       }
 
       // Append backend configurations

--- a/src/components/autoregressive/Qwen35ConfigGenerator/index.js
+++ b/src/components/autoregressive/Qwen35ConfigGenerator/index.js
@@ -251,8 +251,13 @@ const Qwen35ConfigGenerator = () => {
       const epValue = hwConfig.ep;
       const memFraction = hwConfig.mem;
 
+      // Prepend SGLANG_ENABLE_SPEC_V2=1 for B200 FP8 + MTP (validated InferenceX#1065)
+      const envPrefix = (hardware === 'b200' && quantization === 'fp8' && speculative === 'enabled')
+        ? 'SGLANG_ENABLE_SPEC_V2=1 '
+        : '';
+
       // Initialize the base command
-      let cmd = `sglang serve --model-path ${modelName}`;
+      let cmd = `${envPrefix}sglang serve --model-path ${modelName}`;
       if (tpValue > 1) {
         cmd += ` \\\n  --tp ${tpValue}`;
       }
@@ -299,7 +304,7 @@ const Qwen35ConfigGenerator = () => {
         }
       }
 
-      // B200 FP8-specific optimizations (validated in InferenceX#1027)
+      // B200 FP8-specific optimizations (validated in InferenceX#1027 and #1065 for MTP)
       if (hardware === 'b200' && quantization === 'fp8') {
         cmd += ` \\\n  --enable-symm-mem`;
         cmd += ` \\\n  --disable-radix-cache`;
@@ -310,6 +315,9 @@ const Qwen35ConfigGenerator = () => {
         cmd += ` \\\n  --chunked-prefill-size 16384`;
         cmd += ` \\\n  --max-prefill-tokens 16384`;
         cmd += ` \\\n  --stream-interval 50`;
+        if (speculative === 'enabled') {
+          cmd += ` \\\n  --tokenizer-worker-num 6`;
+        }
       }
 
       // Append backend configurations

--- a/src/components/autoregressive/Qwen35ConfigGenerator/index.js
+++ b/src/components/autoregressive/Qwen35ConfigGenerator/index.js
@@ -251,8 +251,8 @@ const Qwen35ConfigGenerator = () => {
       const epValue = hwConfig.ep;
       const memFraction = hwConfig.mem;
 
-      // Prepend SGLANG_ENABLE_SPEC_V2=1 for B200 FP8 + MTP (validated InferenceX#1065)
-      const envPrefix = (hardware === 'b200' && quantization === 'fp8' && speculative === 'enabled')
+      // Prepend SGLANG_ENABLE_SPEC_V2=1 for B200 FP8 + MTP (InferenceX#1065) and B200 FP4 + MTP (InferenceX#1257)
+      const envPrefix = (hardware === 'b200' && (quantization === 'fp8' || quantization === 'fp4') && speculative === 'enabled')
         ? 'SGLANG_ENABLE_SPEC_V2=1 '
         : '';
 

--- a/src/components/autoregressive/Qwen35ConfigGenerator/index.js
+++ b/src/components/autoregressive/Qwen35ConfigGenerator/index.js
@@ -22,7 +22,7 @@ import ConfigGenerator from '../../base/ConfigGenerator';
  *   35B-A3B:   H100 tp=1, H200 tp=1, B200 tp=1, B300 tp=1, MI300X tp=1, MI325X tp=1, MI355X tp=1
  *   27B:       tp=1 on all hardware (including MI300X, MI325X, MI355X)
  *
- * FP4 (397B only, Blackwell required): B200 tp=4, B300 tp=2
+ * FP4 (397B only, Blackwell required): B200 tp=2, B300 tp=2
  */
 
 const MOE_MODELS = new Set(['397b', '122b', '35b']);
@@ -156,7 +156,7 @@ const Qwen35ConfigGenerator = () => {
       '397b': {
         h100: { bf16: { tp: 16, mem: 0.8 }, fp8: { tp: 8, mem: 0.8 } },
         h200: { bf16: { tp: 8,  mem: 0.8 }, fp8: { tp: 8, ep: 8, mem: 0.8 } },
-        b200: { bf16: { tp: 8,  mem: 0.8 }, fp8: { tp: 4, mem: 0.8 }, fp4: { tp: 4, mem: 0.85 } },
+        b200: { bf16: { tp: 8,  mem: 0.8 }, fp8: { tp: 4, mem: 0.8 }, fp4: { tp: 2, mem: 0.8 } },
         b300: { bf16: { tp: 4,  mem: 0.8 }, fp8: { tp: 2, mem: 0.8 }, fp4: { tp: 2, mem: 0.8 } },
         mi300x: { bf16: { tp: 8, mem: 0.8 }, fp8: { tp: 4, mem: 0.8 } },
         mi325x: { bf16: { tp: 4, mem: 0.8 }, fp8: { tp: 2, mem: 0.8 } },
@@ -337,17 +337,22 @@ const Qwen35ConfigGenerator = () => {
         }
       }
 
-      // FP4-specific backend settings
+      // FP4-specific backend settings (B200 validated in InferenceX#1018)
       if (quantization === 'fp4') {
+        cmd += ' \\\n  --enable-symm-mem';
         cmd += ' \\\n  --quantization modelopt_fp4';
-        cmd += ' \\\n  --fp4-gemm-backend flashinfer_cutlass';
         cmd += ' \\\n  --kv-cache-dtype fp8_e4m3';
+        if (MOE_MODELS.has(model)) {
+          cmd += ' \\\n  --mamba-ssm-dtype bfloat16';
+        }
         cmd += ' \\\n  --moe-runner-backend flashinfer_trtllm';
-        cmd += ' \\\n  --chunked-prefill-size 32768';
-        cmd += ' \\\n  --max-prefill-tokens 32768';
-        cmd += ' \\\n  --max-running-requests 128';
-        cmd += ' \\\n  --stream-interval 30';
+        cmd += ' \\\n  --chunked-prefill-size 16384';
+        cmd += ' \\\n  --max-prefill-tokens 16384';
+        cmd += ' \\\n  --stream-interval 50';
         cmd += ' \\\n  --disable-radix-cache';
+        if (speculative === 'enabled') {
+          cmd += ' \\\n  --tokenizer-worker-num 6';
+        }
       }
 
       // Add memory fraction last


### PR DESCRIPTION
Extend the SGLANG_ENABLE_SPEC_V2=1 env prefix to cover B200 FP4 + MTP. The other flags (--enable-symm-mem, --speculative-* EAGLE, prefill 16384, stream 50, --tokenizer-worker-num, etc.) are already handled by the FP4 base block (#264) and the speculative option. Stacks on #263 (envPrefix scaffold) and #264 (FP4 base flags). Based on SemiAnalysisAI/InferenceX#1257.