### PR TITLE
Add FP8 support on MI355X for GLM-5 cookbook

### DIFF
--- a/data/models/generated/v0.5.8/glm5.yaml
+++ b/data/models/generated/v0.5.8/glm5.yaml
@@ -177,6 +177,116 @@ families:
             - '4'
           prefill: null
           decode: null
+      MI300X:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: bf16
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args: []
+          prefill: null
+          decode: null
+        - name: high-throughput-dp
+          attributes:
+            nodes: single
+            optimization: high-throughput
+            quantization: bf16
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: 8
+            ep: null
+            enable_dp_attention: true
+            extra_args: []
+          prefill: null
+          decode: null
+        - name: speculative-mtp
+          attributes:
+            nodes: single
+            optimization: low-latency
+            quantization: bf16
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --speculative-algorithm
+            - EAGLE
+            - --speculative-num-steps
+            - '3'
+            - --speculative-eagle-topk
+            - '1'
+            - --speculative-num-draft-tokens
+            - '4'
+          prefill: null
+          decode: null
+      MI355X:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: bf16
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args: []
+          prefill: null
+          decode: null
+        - name: high-throughput-dp
+          attributes:
+            nodes: single
+            optimization: high-throughput
+            quantization: bf16
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: 8
+            ep: null
+            enable_dp_attention: true
+            extra_args: []
+          prefill: null
+          decode: null
+        - name: speculative-mtp
+          attributes:
+            nodes: single
+            optimization: low-latency
+            quantization: bf16
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: null
+            ep: null
+            enable_dp_attention: null
+            extra_args:
+            - --speculative-algorithm
+            - EAGLE
+            - --speculative-num-steps
+            - '3'
+            - --speculative-eagle-topk
+            - '1'
+            - --speculative-num-draft-tokens
+            - '4'
+          prefill: null
+          decode: null
   - name: GLM-5-NVFP4
     model_path: nvidia/GLM-5-NVFP4
     attributes:
@@ -250,7 +360,7 @@ families:
         reasoning_parser: glm45
         chat_template: null
     hardware:
-      H100:
+      MI355X:
         configurations:
         - name: default
           attributes:
@@ -260,7 +370,7 @@ families:
           quantized_model_path: null
           engine:
             env_vars: {}
-            tp: 16
+            tp: 4
             dp: null
             ep: null
             enable_dp_attention: null
@@ -275,7 +385,7 @@ families:
           quantized_model_path: null
           engine:
             env_vars: {}
-            tp: 16
+            tp: 4
             dp: 8
             ep: null
             enable_dp_attention: true
@@ -290,117 +400,7 @@ families:
           quantized_model_path: null
           engine:
             env_vars: {}
-            tp: 16
-            dp: null
-            ep: null
-            enable_dp_attention: null
-            extra_args:
-            - --speculative-algorithm
-            - EAGLE
-            - --speculative-num-steps
-            - '3'
-            - --speculative-eagle-topk
-            - '1'
-            - --speculative-num-draft-tokens
-            - '4'
-          prefill: null
-          decode: null
-      H200:
-        configurations:
-        - name: default
-          attributes:
-            nodes: single
-            optimization: balanced
-            quantization: fp8
-          quantized_model_path: null
-          engine:
-            env_vars: {}
-            tp: 8
-            dp: null
-            ep: null
-            enable_dp_attention: null
-            extra_args: []
-          prefill: null
-          decode: null
-        - name: high-throughput-dp
-          attributes:
-            nodes: single
-            optimization: high-throughput
-            quantization: fp8
-          quantized_model_path: null
-          engine:
-            env_vars: {}
-            tp: 8
-            dp: 8
-            ep: null
-            enable_dp_attention: true
-            extra_args: []
-          prefill: null
-          decode: null
-        - name: speculative-mtp
-          attributes:
-            nodes: single
-            optimization: low-latency
-            quantization: fp8
-          quantized_model_path: null
-          engine:
-            env_vars: {}
-            tp: 8
-            dp: null
-            ep: null
-            enable_dp_attention: null
-            extra_args:
-            - --speculative-algorithm
-            - EAGLE
-            - --speculative-num-steps
-            - '3'
-            - --speculative-eagle-topk
-            - '1'
-            - --speculative-num-draft-tokens
-            - '4'
-          prefill: null
-          decode: null
-      B200:
-        configurations:
-        - name: default
-          attributes:
-            nodes: single
-            optimization: balanced
-            quantization: fp8
-          quantized_model_path: null
-          engine:
-            env_vars: {}
-            tp: 8
-            dp: null
-            ep: null
-            enable_dp_attention: null
-            extra_args: []
-          prefill: null
-          decode: null
-        - name: high-throughput-dp
-          attributes:
-            nodes: single
-            optimization: high-throughput
-            quantization: fp8
-          quantized_model_path: null
-          engine:
-            env_vars: {}
-            tp: 8
-            dp: 8
-            ep: null
-            enable_dp_attention: true
-            extra_args: []
-          prefill: null
-          decode: null
-        - name: speculative-mtp
-          attributes:
-            nodes: single
-            optimization: low-latency
-            quantization: fp8
-          quantized_model_path: null
-          engine:
-            env_vars: {}
-            tp: 8
+            tp: 4
             dp: null
             ep: null
             enable_dp_attention: null

--- a/data/models/src/v0.5.8/glm5.yaml
+++ b/data/models/src/v0.5.8/glm5.yaml
@@ -5,6 +5,8 @@
 #   H100: FP8 tp=16, BF16 tp=32
 #   H200: FP8 tp=8, BF16 tp=16
 #   B200: NVFP4 tp=4, FP8 tp=8, BF16 tp=16
+#   MI300X/MI325X: BF16 tp=8
+#   MI355X: FP8 tp=4, BF16 tp=8
 
 vendor: zai-org
 
@@ -13,6 +15,8 @@ defaults:
     H100: { tp: 16 }
     H200: { tp: 8 }
     B200: { tp: 8 }
+    MI300X: { tp: 8 }
+    MI355X: { tp: 4 }
   configurations:
     - name: default
       nodes: single
@@ -51,6 +55,8 @@ families:
           H100: { tp: 32 }
           H200: { tp: 16 }
           B200: { tp: 16 }
+          MI300X: { tp: 8 }
+          MI355X: { tp: 8 }
 
       # GLM-5 NVFP4 (Blackwell only)
       - name: GLM-5-NVFP4
@@ -62,3 +68,5 @@ families:
       # GLM-5 FP8
       - name: GLM-5-FP8
         quantization: fp8
+        hardware:
+          MI355X: { tp: 4 }

--- a/docs/autoregressive/GLM/GLM-5.md
+++ b/docs/autoregressive/GLM/GLM-5.md
@@ -51,11 +51,11 @@ import GLM5ConfigGenerator from '@site/src/components/autoregressive/GLM5ConfigG
 | H200     | tp=8  | tp=16 |
 | B200     | tp=8  | tp=16 |
 | MI300X/MI325X | — | tp=8 |
-| MI355X   | — | tp=8 |
+| MI355X   | tp=4 | tp=8 |
 
 - **B200 (FP8)**: Use `--ep 1 --attention-backend nsa --nsa-decode-backend trtllm --nsa-prefill-backend trtllm --moe-runner-backend flashinfer_trtllm --enable-flashinfer-allreduce-fusion` for optimized NSA and MoE backends on Blackwell. Also add `--quantization fp8` for FP8 weight quantization.
 
-- **AMD GPUs**: Use `--nsa-prefill-backend tilelang --nsa-decode-backend tilelang` for the NSA attention backend. Add `--chunked-prefill-size 131072` and `--watchdog-timeout 1200` (20 minutes for weight loading). EAGLE speculative decoding is not currently supported on AMD for GLM-5.
+- **AMD GPUs**: Use `--nsa-prefill-backend tilelang --nsa-decode-backend tilelang` for the NSA attention backend. Add `--chunked-prefill-size 131072` and `--watchdog-timeout 1200` (20 minutes for weight loading). FP8 is supported on MI355X with `--kv-cache-dtype fp8_e4m3 --disable-radix-cache` (tp=4). EAGLE speculative decoding is not currently supported on MI300X/MI325X for GLM-5.
 - For other configuration tips, please refer to [DeepSeek V3.2 documentation](https://docs.sglang.io/basic_usage/deepseek_v32.html). GLM-5 and DeepSeek V3.2 share the same model structure, so the optimization techniques between these two models are also common (MTP, DSA kernel, Context Parallel...).
 - Use `--json-model-override-args '{"index_topk_pattern": "FFSFSSSFSSFFFSSSFFFSFSSSSSSFFSFFSFFSSFFFFFFSFFFFFSFFSSSSSSFSFFFSFSSSFSFFSFFSSS"}'` for GLM-5-FP8 if you want to enable the [IndexCache](https://github.com/THUDM/IndexCache) method. This feature is supported through [this PR](https://github.com/sgl-project/sglang/pull/21405) and introduces only a small accuracy loss. However, if you are running rigorous accuracy evaluations, it is not recommended to enable this feature.
 
@@ -84,7 +84,9 @@ sglang serve \
 
 ### 4.1 MI300X/MI325X/MI355X (ROCm) Server Command
 
-The following ROCm command is an additional option for AMD GPUs and does not replace the NVIDIA instructions above.
+The following ROCm commands are additional options for AMD GPUs and do not replace the NVIDIA instructions above.
+
+**MI300X/MI325X/MI355X BF16:**
 
 ```shell
 sglang serve \
@@ -95,6 +97,24 @@ sglang serve \
   --nsa-decode-backend tilelang \
   --chunked-prefill-size 131072 \
   --mem-fraction-static 0.80 \
+  --watchdog-timeout 1200 \
+  --host 0.0.0.0 \
+  --port 30000
+```
+
+**MI355X FP8:**
+
+```shell
+sglang serve \
+  --model zai-org/GLM-5-FP8 \
+  --tp 4 \
+  --trust-remote-code \
+  --nsa-prefill-backend tilelang \
+  --nsa-decode-backend tilelang \
+  --chunked-prefill-size 131072 \
+  --kv-cache-dtype fp8_e4m3 \
+  --disable-radix-cache \
+  --mem-fraction-static 0.85 \
   --watchdog-timeout 1200 \
   --host 0.0.0.0 \
   --port 30000

--- a/src/components/autoregressive/GLM5ConfigGenerator/index.js
+++ b/src/components/autoregressive/GLM5ConfigGenerator/index.js
@@ -11,7 +11,7 @@ import ConfigGenerator from '../../base/ConfigGenerator';
  *   H200: FP8 tp=8, BF16 tp=16
  *   B200: NVFP4 tp=4, FP8 tp=8, BF16 tp=16
  *   MI300X/MI325X: BF16 tp=8
- *   MI355X: BF16 tp=8
+ *   MI355X: FP8 tp=4, BF16 tp=8
  */
 const GLM5ConfigGenerator = () => {
   const config = {
@@ -34,11 +34,11 @@ const GLM5ConfigGenerator = () => {
         title: 'Quantization',
         getDynamicItems: (values) => {
           const hw = values.hardware;
-          const isAMD = hw === 'mi300x' || hw === 'mi355x';
+          const isMI300X = hw === 'mi300x';
           const isB200 = hw === 'b200';
           return [
-            { id: 'bf16', label: 'BF16', subtitle: 'Full Weights', default: isAMD },
-            { id: 'fp8', label: 'FP8', subtitle: 'High Throughput', default: !isAMD && !isB200, disabled: isAMD, disabledReason: isAMD ? 'FP8 not verified on AMD' : '' },
+            { id: 'bf16', label: 'BF16', subtitle: 'Full Weights', default: isMI300X },
+            { id: 'fp8', label: 'FP8', subtitle: 'High Throughput', default: !isMI300X && !isB200, disabled: isMI300X, disabledReason: isMI300X ? 'FP8 not verified on MI300X/MI325X' : '' },
             { id: 'nvfp4', label: 'NVFP4', subtitle: 'Highest Throughput', default: isB200, disabled: !isB200, disabledReason: !isB200 ? 'NVFP4 only available on B200' : '' }
           ];
         }
@@ -77,7 +77,7 @@ const GLM5ConfigGenerator = () => {
       speculative: {
         name: 'speculative',
         title: 'Speculative Decoding',
-        condition: (values) => values.hardware !== 'mi300x' && values.hardware !== 'mi355x' && values.quantization !== 'nvfp4',
+        condition: (values) => values.hardware !== 'mi300x' && values.quantization !== 'nvfp4',
         items: [
           { id: 'disabled', label: 'Disabled', default: false },
           { id: 'enabled', label: 'Enabled', default: true }
@@ -92,16 +92,18 @@ const GLM5ConfigGenerator = () => {
       h200: { fp8: { tp: 8, mem: 0.85 }, bf16: { tp: 16, mem: 0.85 } },
       b200: { nvfp4: { tp: 4, mem: 0.9 }, fp8: { tp: 8, mem: 0.9 }, bf16: { tp: 16, mem: 0.9 } },
       mi300x: { bf16: { tp: 8, mem: 0.80 } },
-      mi355x: { bf16: { tp: 8, mem: 0.80 } }
+      mi355x: { fp8: { tp: 4, mem: 0.85 }, bf16: { tp: 8, mem: 0.80 } }
     },
 
     generateCommand: function (values) {
       const { hardware, quantization } = values;
-      const isAMD = hardware === 'mi300x' || hardware === 'mi355x';
+      const isMI300X = hardware === 'mi300x';
+      const isMI355X = hardware === 'mi355x';
+      const isAMD = isMI300X || isMI355X;
       const isNVFP4 = quantization === 'nvfp4';
 
-      // AMD only supports BF16; NVIDIA supports BF16, FP8, and NVFP4 (B200 only)
-      const effectiveQuant = isAMD ? 'bf16' : quantization;
+      // MI300X only supports BF16; MI355X supports both BF16 and FP8; NVIDIA supports BF16, FP8, and NVFP4 (B200 only)
+      const effectiveQuant = isMI300X ? 'bf16' : quantization;
 
       // Model name varies by quantization
       let modelName;
@@ -146,6 +148,11 @@ const GLM5ConfigGenerator = () => {
         cmd += ' \\\n  --nsa-decode-backend tilelang';
         cmd += ' \\\n  --chunked-prefill-size 131072';
         cmd += ' \\\n  --watchdog-timeout 1200';
+        // MI355X FP8: additional optimizations from InferenceX benchmarking
+        if (isMI355X && effectiveQuant === 'fp8') {
+          cmd += ' \\\n  --kv-cache-dtype fp8_e4m3';
+          cmd += ' \\\n  --disable-radix-cache';
+        }
       }
 
       // DP Attention: --dp matches --tp


### PR DESCRIPTION
## Summary

- Added FP8 quantization support for MI355X on the GLM-5 cookbook page
- MI355X FP8 uses **tp=4** (aligned with [InferenceX PR #1375](https://github.com/SemiAnalysisAI/InferenceX/pull/1375))
- MI300X/MI325X remain BF16-only

## Changes

### ConfigGenerator (`GLM5ConfigGenerator/index.js`)
- Enable FP8 selection when MI355X is selected (remains disabled on MI300X/MI325X)
- Add MI355X FP8 config: tp=4, mem=0.85
- Add `--kv-cache-dtype fp8_e4m3` and `--disable-radix-cache` flags for MI355X FP8
- FP8 defaults to selected when MI355X is chosen (matching NVIDIA behavior)

### Documentation (`GLM-5.md`)
- Update hardware table: MI355X now shows FP8 tp=4
- Add dedicated MI355X FP8 server command example
- Update AMD GPU tips to reflect FP8 support on MI355X

### YAML Configs (`data/models/src/v0.5.8/glm5.yaml`)
- Add MI300X (tp=8) and MI355X (tp=4) to hardware defaults
- Add MI355X FP8 (tp=4) to GLM-5-FP8 model entry
- Add MI300X/MI355X BF16 (tp=8) overrides to GLM-5 BF16 model entry

## Reference
- InferenceX PR: https://github.com/SemiAnalysisAI/InferenceX/pull/1375
- Image: `lmsysorg/sglang-rocm:v0.5.11-rocm720-mi35x-20260513`
- Verified command on AMD MI355X GPUs