### PR TITLE
Add MI300X support for GLM-4.7-Flash

### DIFF
--- a/docs/autoregressive/GLM/GLM-4.7-Flash.md
+++ b/docs/autoregressive/GLM/GLM-4.7-Flash.md
@@ -18,7 +18,7 @@ For more details, please refer to the [official GLM-4.7 documentation](https://d
 
 - **Efficient MoE Architecture**: 30B-A3B sparse activation for optimal performance/efficiency trade-off
 - **Multiple Quantizations**: BF16 and FP8 variants for different performance/memory trade-offs
-- **Hardware Optimization**: Specifically tuned for NVIDIA H100/H200/B200 GPUs
+- **Hardware Optimization**: Specifically tuned for NVIDIA H100/H200/B200 and AMD MI300X GPUs
 - **High Performance**: Optimized for both throughput and latency scenarios
 
 **Available Models:**
@@ -38,6 +38,35 @@ Please refer to the [official SGLang installation guide](https://docs.sglang.ai/
 ## 3. Model Deployment
 
 This section provides deployment configurations optimized for different hardware platforms and use cases.
+
+### AMD GPU (MI300X) Docker Deployment
+
+For AMD MI300X GPUs, use the official SGLang ROCm Docker image:
+
+```bash
+docker run -d --name sglang_glm47flash \
+  --device=/dev/kfd --device=/dev/dri \
+  --security-opt seccomp=unconfined \
+  --group-add video \
+  --ipc=host --shm-size 64g \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  -p 30000:30000 \
+  -e SGLANG_USE_AITER=0 \
+  -e USE_ROCM_AITER_ROPE_BACKEND=0 \
+  lmsysorg/sglang:v0.5.11-rocm720-mi30x \
+  python3 -m sglang.launch_server \
+    --model zai-org/GLM-4.7-Flash \
+    --tp 1 \
+    --trust-remote-code \
+    --attention-backend triton \
+    --host 0.0.0.0 --port 30000
+```
+
+:::tip AMD-Specific Notes
+- **Environment Variables**: `SGLANG_USE_AITER=0` and `USE_ROCM_AITER_ROPE_BACKEND=0` are required to avoid incompatibilities with the aiter rope backend for MLA-based models on MI300X.
+- **Attention Backend**: `--attention-backend triton` is required for AMD GPUs.
+- **Trust Remote Code**: `--trust-remote-code` is required for this model on AMD.
+:::
 
 ### 3.1 Basic Configuration
 

--- a/src/components/autoregressive/GLM47FlashConfigGenerator/index.js
+++ b/src/components/autoregressive/GLM47FlashConfigGenerator/index.js
@@ -4,7 +4,7 @@ import ConfigGenerator from '../../base/ConfigGenerator';
 /**
  * GLM-4.7-Flash Configuration Generator
  * Supports GLM-4.7-Flash model deployment configuration
- * Hardware options: H100, H200, B200
+ * Hardware options: H100, H200, B200, MI300X
  */
 const GLM47FlashConfigGenerator = () => {
   const config = {
@@ -17,7 +17,8 @@ const GLM47FlashConfigGenerator = () => {
         items: [
           { id: 'h100', label: 'H100', default: true },
           { id: 'h200', label: 'H200', default: false },
-          { id: 'b200', label: 'B200', default: false }
+          { id: 'b200', label: 'B200', default: false },
+          { id: 'mi300x', label: 'MI300X', default: false }
         ]
       },
       quantization: {
@@ -63,17 +64,36 @@ const GLM47FlashConfigGenerator = () => {
       const { hardware, quantization, strategy, thinking, toolcall } = values;
 
       const strategyArray = Array.isArray(strategy) ? strategy : [];
+      const isMI300X = hardware === 'mi300x';
 
       const modelName = `${this.modelFamily}/GLM-4.7-Flash`;
 
       // GLM-4.7-Flash is a 30B-A3B MoE model, lighter than GLM-4.7
       const tpValue = 1; // Default for single GPU
 
-      let cmd = 'python -m sglang.launch_server \\\n ';
+      // MI300X: MTP (speculative decoding) is not yet supported
+      if (isMI300X && strategyArray.includes('mtp')) {
+        return '# MI300X Speculative Decoding (EAGLE): Work In Progress\\n'
+            + '# Uncheck "Multi-token Prediction (MTP)" to view the validated non-speculative MI300X command.';
+      }
+
+      let cmd = '';
+
+      // MI300X requires specific environment variables
+      if (isMI300X) {
+        cmd += 'SGLANG_USE_AITER=0 USE_ROCM_AITER_ROPE_BACKEND=0 ';
+      }
+
+      cmd += 'python -m sglang.launch_server \\\n ';
       cmd += `  --model ${modelName}`;
 
       // TP is mandatory
       cmd += ` \\\n   --tp ${tpValue}`;
+
+      // MI300X: trust-remote-code and triton attention backend
+      if (isMI300X) {
+        cmd += ` \\\n   --trust-remote-code \\\n   --attention-backend triton`;
+      }
 
       if (hardware === 'b200') {
         cmd += ` \\\n   --attention-backend triton`;
@@ -83,7 +103,7 @@ const GLM47FlashConfigGenerator = () => {
       if (strategyArray.includes('dp')) {
         cmd += ` \\\n   --dp 1 \\\n   --enable-dp-attention`;
       }
-      if (strategyArray.includes('mtp')) {
+      if (!isMI300X && strategyArray.includes('mtp')) {
         cmd = 'SGLANG_ENABLE_SPEC_V2=1 ' + cmd;
 
         if (hardware === 'b200') {


### PR DESCRIPTION
## Summary

Add AMD MI300X support for the GLM-4.7-Flash cookbook page.

### Changes
- Added MI300X hardware option to the interactive ConfigGenerator
- Added AMD ROCm Docker deployment section with validated commands
- Required environment variables: `SGLANG_USE_AITER=0`, `USE_ROCM_AITER_ROPE_BACKEND=0`
- Required flags: `--trust-remote-code`, `--attention-backend triton`
- MTP (speculative decoding) disabled for MI300X (not yet supported)

### Testing
- Verified on MI300X (tp=1) with `lmsysorg/sglang:v0.5.11-rocm720-mi30x` Docker image
- Server starts and responds to inference requests successfully
- GLM-4.7-Flash (30B-A3B MoE) fits in a single MI300X GPU (192 GB HBM3)

### Docker Command
```bash
docker run -d --name sglang_glm47flash \
  --device=/dev/kfd --device=/dev/dri \
  --security-opt seccomp=unconfined \
  --group-add video \
  --ipc=host --shm-size 64g \
  -p 30000:30000 \
  -e SGLANG_USE_AITER=0 \
  -e USE_ROCM_AITER_ROPE_BACKEND=0 \
  lmsysorg/sglang:v0.5.11-rocm720-mi30x \
  python3 -m sglang.launch_server \
    --model zai-org/GLM-4.7-Flash \
    --tp 1 --trust-remote-code \
    --attention-backend triton \
    --host 0.0.0.0 --port 30000
```