### PR TITLE
Add MI300X support for MiMo-V2-Flash

### DIFF
--- a/docs/autoregressive/Xiaomi/MiMo-V2-Flash.md
+++ b/docs/autoregressive/Xiaomi/MiMo-V2-Flash.md
@@ -58,6 +58,39 @@ import MiMoConfigGenerator from '@site/src/components/autoregressive/MiMoConfigG
 
 MI355X (ROCm) is validated in the selector above with `--tp-size 4`, Triton attention, and `--disable-custom-all-reduce`. `--tp-size 8` hit a QKV sharding error during validation. EAGLE speculative decoding is still WIP on MI355X.
 
+### AMD MI300X Docker Deployment
+
+For AMD MI300X GPUs, use the official SGLang ROCm Docker image:
+
+```bash
+docker run -d --name sglang_mimo_v2_flash \
+  --device=/dev/kfd --device=/dev/dri \
+  --security-opt seccomp=unconfined \
+  --group-add video \
+  --ipc=host --shm-size 64g \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  -p 30000:30000 \
+  -e SGLANG_USE_AITER=0 \
+  -e USE_ROCM_AITER_ROPE_BACKEND=0 \
+  lmsysorg/sglang:v0.5.11-rocm720-mi30x \
+  bash -c "SGLANG_USE_AITER=0 USE_ROCM_AITER_ROPE_BACKEND=0 \
+    python3 -m sglang.launch_server \
+    --model XiaomiMiMo/MiMo-V2-Flash \
+    --tp 2 --trust-remote-code \
+    --mem-fraction-static 0.80 \
+    --attention-backend triton \
+    --disable-cuda-graph \
+    --disable-custom-all-reduce \
+    --host 0.0.0.0 --port 30000"
+```
+
+:::tip AMD MI300X Notes
+- **TP=2**: MiMo-V2-Flash (309B total / 15B active MoE) requires at least 2 MI300X GPUs.
+- **`--disable-cuda-graph`**: Required on MI300X to avoid FP8 Triton kernel compilation errors.
+- **Environment Variables**: `SGLANG_USE_AITER=0` and `USE_ROCM_AITER_ROPE_BACKEND=0` are required for MLA model compatibility on AMD.
+- **EAGLE speculative decoding**: Not yet supported on MI300X.
+:::
+
 ## Testing the deployment
 
 Once the server is running, test it with a chat completion request in another terminal:

--- a/src/components/autoregressive/MiMoConfigGenerator/index.js
+++ b/src/components/autoregressive/MiMoConfigGenerator/index.js
@@ -15,6 +15,7 @@ const MiMoConfigGenerator = () => {
             items: [
                 { id: 'h200', label: 'H200', default: true },
                 { id: 'h100', label: 'H100', default: false },
+                { id: 'mi300x', label: 'MI300X', default: false },
                 { id: 'mi355x', label: 'MI355X', default: false }
             ]
         },
@@ -50,41 +51,58 @@ const MiMoConfigGenerator = () => {
     generateCommand: function(values) {
         const { hardware, strategy, reasoning } = values;
         const isMI355X = hardware === 'mi355x';
+        const isMI300X = hardware === 'mi300x';
+        const isAMD = isMI300X || isMI355X;
 
         const modelPath = 'XiaomiMiMo/MiMo-V2-Flash';
         const strategyArray = Array.isArray(strategy) ? strategy : [];
         const reasoningArray = Array.isArray(reasoning) ? reasoning : [];
 
-        if (isMI355X && strategyArray.includes('mtp')) {
-            return '# MI355X Speculative Decoding (EAGLE): Work In Progress\n'
-                + '# Uncheck "Multi-token Prediction (MTP)" to view the validated non-speculative MI355X command.';
+        // AMD: MTP (speculative decoding) is not yet supported
+        if (isAMD && strategyArray.includes('mtp')) {
+            const gpuName = isMI300X ? 'MI300X' : 'MI355X';
+            return `# ${gpuName} Speculative Decoding (EAGLE): Work In Progress\\n`
+                + `# Uncheck "Multi-token Prediction (MTP)" to view the validated non-speculative ${gpuName} command.`;
         }
 
-        const commandPrefix = isMI355X
-            ? 'PYTHONPATH=/sgl-workspace/aiter SGLANG_USE_AITER=0 USE_ROCM_AITER_ROPE_BACKEND=0'
-            : 'SGLANG_ENABLE_SPEC_V2=1';
-        const tpSize = isMI355X ? 4 : 8;
+        let commandPrefix;
+        let tpSize;
+        if (isMI300X) {
+            commandPrefix = 'SGLANG_USE_AITER=0 USE_ROCM_AITER_ROPE_BACKEND=0';
+            tpSize = 2;
+        } else if (isMI355X) {
+            commandPrefix = 'PYTHONPATH=/sgl-workspace/aiter SGLANG_USE_AITER=0 USE_ROCM_AITER_ROPE_BACKEND=0';
+            tpSize = 4;
+        } else {
+            commandPrefix = 'SGLANG_ENABLE_SPEC_V2=1';
+            tpSize = 8;
+        }
 
         let cmd = `${commandPrefix} sglang serve \\\n`;
         cmd += `  --model-path ${modelPath} \\\n`;
         cmd += `  --trust-remote-code \\\n`;
         cmd += `  --tp-size ${tpSize}`;
 
-        // DP settings
-        if (!isMI355X && strategyArray.includes('dp')) {
+        // DP settings (NVIDIA only)
+        if (!isAMD && strategyArray.includes('dp')) {
             cmd += ` \\\n  --dp-size 2 \\\n  --enable-dp-attention`;
         }
 
         // Performance Optimizations
         if (strategyArray.includes('optimization')) {
-             cmd += ` \\\n  --mem-fraction-static 0.75 \\\n  --max-running-requests 128 \\\n  --chunked-prefill-size 16384 \\\n  --model-loader-extra-config '{"enable_multithread_load": "true","num_threads": 64}'`;
-             cmd += isMI355X
-                 ? ` \\\n  --attention-backend triton \\\n  --prefill-attention-backend triton \\\n  --decode-attention-backend triton \\\n  --disable-custom-all-reduce`
-                 : ` \\\n  --attention-backend fa3`;
+             if (isMI300X) {
+                 cmd += ` \\\n  --mem-fraction-static 0.80 \\\n  --attention-backend triton \\\n  --prefill-attention-backend triton \\\n  --decode-attention-backend triton \\\n  --disable-cuda-graph \\\n  --disable-custom-all-reduce`;
+             } else if (isMI355X) {
+                 cmd += ` \\\n  --mem-fraction-static 0.75 \\\n  --max-running-requests 128 \\\n  --chunked-prefill-size 16384 \\\n  --model-loader-extra-config '{"enable_multithread_load": "true","num_threads": 64}'`;
+                 cmd += ` \\\n  --attention-backend triton \\\n  --prefill-attention-backend triton \\\n  --decode-attention-backend triton \\\n  --disable-custom-all-reduce`;
+             } else {
+                 cmd += ` \\\n  --mem-fraction-static 0.75 \\\n  --max-running-requests 128 \\\n  --chunked-prefill-size 16384 \\\n  --model-loader-extra-config '{"enable_multithread_load": "true","num_threads": 64}'`;
+                 cmd += ` \\\n  --attention-backend fa3`;
+             }
         }
 
-        // MTP/Speculative settings
-        if (!isMI355X && strategyArray.includes('mtp')) {
+        // MTP/Speculative settings (NVIDIA only)
+        if (!isAMD && strategyArray.includes('mtp')) {
             cmd += ` \\\n  --speculative-algorithm EAGLE \\\n  --speculative-num-steps 3 \\\n  --speculative-eagle-topk 1 \\\n  --speculative-num-draft-tokens 4 \\\n  --enable-multi-layer-eagle`;
         }
 


### PR DESCRIPTION
Add AMD MI300X support for MiMo-V2-Flash cookbook. tp=2, --disable-cuda-graph required for FP8 Triton compat. Tested on MI300X with sglang v0.5.11-rocm720-mi30x.