### PR TITLE
docs: add AMD MI355X deployment section for Qwen3.6-35B-A3B-FP8

### DIFF
--- a/docs/autoregressive/Qwen/Qwen3.6.md
+++ b/docs/autoregressive/Qwen/Qwen3.6.md
@@ -424,3 +424,24 @@ for chunk in response:
 
 print()
 ```
+
+## 5. AMD MI355X
+
+### Docker Setup
+
+```bash
+docker run -d   --device=/dev/kfd --device=/dev/dri   --group-add video --cap-add=SYS_PTRACE   --security-opt seccomp=unconfined   --shm-size=32g --ipc=host --network=host   lmsysorg/sglang-rocm:v0.5.11-rocm720-mi30x-20260513 bash
+```
+
+### Model Deployment
+
+```bash
+python   -m sglang.launch_server   --model Qwen/Qwen3.6-35B-A3B-FP8   --tp 1   --reasoning-parser qwen3
+```
+
+### Benchmark Results
+
+| Task | Shots | Metric | Score |
+|------|-------|--------|-------|
+| gsm8k | 8 | exact_match | 0.5785 |
+


### PR DESCRIPTION
## Add AMD MI355X support for Qwen3.6-35B-A3B-FP8

**Target file:** `docs/autoregressive/Qwen/Qwen3.6-35B-A3B-FP8.md`

## Summary
Adds AMD MI355X GPU support for **[Qwen/Qwen3.6-35B-A3B-FP8](https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8)**.

Tested with `lmsysorg/sglang-rocm:v0.5.11-rocm720-mi30x-20260513`.

---

## Problem

The cookbook page for this model lacks an AMD MI355X section.

---

## Proposed Fix

Append the following section to the cookbook page:

### Model Deployment

```bash
python \
  -m sglang.launch_server \
  --model Qwen/Qwen3.6-35B-A3B-FP8 \
  --tp 1 \
  --reasoning-parser qwen3
```

### Benchmark Results

| Task | Shots | Metric | Score |
|------|-------|--------|-------|
| gsm8k | 8 | exact_match | 0.5785 |

---

## Checklist

- [x] Model server starts successfully on MI355X
- [x] gsm8k benchmark passes
- [ ] Cookbook page reviewed
- [ ] PR approved by maintainer

---


## Benchmark Results

| Date | Config | gsm8k 8-shot |
|------|--------|--------------|
| 15/05/2026 11:31 | TP=1, `reasoning-parser=qwen3` | 0.5785 |
| 15/05/2026 15:06 | TP=, `mem-fraction-static=0.8` `reasoning-parser=qwen3` `tool-call-parser=qwen3_coder` | 0.4996 |

## Testing

- [x] Model server starts successfully on MI355X
- [x] gsm8k benchmark passes

---
_Benchmarked with [auto_sglang](https://github.com/amd-internal/auto_sglang)_