### PR TITLE
docs: Add AMD MI355X and MI300X support for Laguna-XS.2

### DIFF
--- a/docs/autoregressive/poolside/Laguna-XS.2.md
+++ b/docs/autoregressive/poolside/Laguna-XS.2.md
@@ -1,0 +1,29 @@
+
+
+## AMD MI355X
+
+### Model Deployment
+
+```bash
+sglang serve \
+  --model-path poolside/Laguna-XS.2 \
+  --tp 8 \
+  --reasoning-parser poolside_v1 \
+  --tool-call-parser poolside_v1 \
+  --host 0.0.0.0 \
+  --port 30000
+```
+
+## AMD MI300X
+
+### Model Deployment
+
+```bash
+sglang serve \
+  --model-path poolside/Laguna-XS.2 \
+  --tp 8 \
+  --reasoning-parser poolside_v1 \
+  --tool-call-parser poolside_v1 \
+  --host 0.0.0.0 \
+  --port 30000
+```


### PR DESCRIPTION
## Problem

The cookbook page for this model lacks an AMD MI355X section.

---

## Proposed Fix

Append the following section to the cookbook page:

## AMD MI355X

### Model Deployment

```bash
sglang serve \
  --model-path poolside/Laguna-XS.2 \
  --tp 8 \
  --reasoning-parser poolside_v1 \
  --tool-call-parser poolside_v1 \
  --host 0.0.0.0 \
  --port 30000
```

## AMD MI300X

### Model Deployment

```bash
sglang serve \
  --model-path poolside/Laguna-XS.2 \
  --tp 8 \
  --reasoning-parser poolside_v1 \
  --tool-call-parser poolside_v1 \
  --host 0.0.0.0 \
  --port 30000
```