### PR TITLE
Add AMD MI300X and AMD MI355X support for Intern-S2-Preview

### DIFF
--- a/docs/autoregressive/InternLM/Intern-S2-Preview.md
+++ b/docs/autoregressive/InternLM/Intern-S2-Preview.md
@@ -1,0 +1,32 @@
+
+
+```markdown
+## AMD MI355X
+
+### Docker Setup
+
+```bash
+docker run -d \
+  --device=/dev/kfd --device=/dev/dri \
+  --group-add video --cap-add=SYS_PTRACE \
+  --security-opt seccomp=unconfined \
+  --shm-size=32g --ipc=host --network=host \
+  lmsysorg/sglang-rocm:v0.5.12-rocm720-mi30x-20260517 bash
+```
+
+### Model Deployment
+
+```bash
+python \
+  -m sglang.launch_server \
+  --model InternLM/Intern-S2-Preview \
+  --tp 8 \
+  --attention-backend triton \
+  --trust-remote-code \
+  --context-length 8192 \
+  --mem-fraction-static 0.85 \
+  --host 0.0.0.0 \
+  --port 30000
+```
+
+#


### PR DESCRIPTION
## Add AMD MI300X and AMD MI355X support for Intern-S2-Preview

**Branch:** `amd-intern-s2-preview-20260519`  
**Target file:** `docs/autoregressive/InternLM/Intern-S2-Preview.md`

---

## Summary

Adds AMD MI300X and AMD MI355X support for **[InternLM/Intern-S2-Preview](https://huggingface.co/InternLM/Intern-S2-Preview)**.

- [x] AMD MI300X: model server starts successfully
- [x] AMD MI300X: gsm8k 8-shot = 0.8893
- [x] AMD MI355X: model server starts successfully
- [x] AMD MI355X: gsm8k 8-shot = 0.8832

_Benchmarked with [auto_sglang](https://github.com/giovanniguastiamd/auto_sglang)_

---

## Proposed Fix

Append the following section to the cookbook page:


## AMD MI355X

### Model Deployment

```bash
sglang serve \
  --model-path internLM/Intern-S2-Preview \
  --tp 8 \
  --reasoning-parser qwen3 \
  --tool-call-parser qwen3_coder \
  --mem-fraction-static 0.8 \
  --host 0.0.0.0 \
  --port 30000 \
  --trust-remote-code
```

### Benchmark Results

| Task | Shots | Metric | Score |
|------|-------|--------|-------|
| gsm8k | 8 | exact_match | 0.8832 |

---

## AMD MI300

### Model Deployment

```bash
python \                                                                                
   -m sglang.launch_server \                                                             
   --model InternLM/Intern-S2-Preview \                                                  
   --tp 8 \                                                                              
   --attention-backend triton \                                                          
   --trust-remote-code \                                                                 
   --context-length 8192 \                                                               
   --mem-fraction-static 0.85 \                                                          
   --host 0.0.0.0 \                                                                      
   --port 30000                                                                          
```

### Benchmark Results                                                                        

                                   
| Task | Shots | Metric | Score |
|------|-------|--------|-------|
| gsm8k | 8 | exact_match | 0.8893 |
                                   

## Checklist

- [x] Model server starts successfully on AMD MI300X
- [x] gsm8k benchmark passes on AMD MI300X
- [x] Model server starts successfully on AMD MI355X
- [x] gsm8k benchmark passes on AMD MI355X
- [ ] Cookbook page reviewed
- [ ] PR approved by maintainer
