### PR TITLE
docs: Add AMD MI355X support for GLM-5.1-FP8

### DIFF
--- a/docs/autoregressive/zai-org/GLM-5.1-FP8.md
+++ b/docs/autoregressive/zai-org/GLM-5.1-FP8.md
@@ -1,0 +1,25 @@
+
+
+## AMD MI355X
+
+### Model Deployment
+
+```bash
+SGLANG_ENABLE_SPEC_V2=1 sglang serve \
+  --model-path zai-org/GLM-5.1-FP8 \
+  --tp 8 \
+  --trust-remote-code \
+  --nsa-prefill-backend tilelang \
+  --nsa-decode-backend tilelang \
+  --chunked-prefill-size 131072 \
+  --watchdog-timeout 1200 \
+  --reasoning-parser glm45 \
+  --tool-call-parser glm47 \
+  --speculative-algorithm EAGLE \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  --mem-fraction-static 0.9
+```
+
+#


### PR DESCRIPTION
## Summary

Adds AMD MI355X support for **[zai-org/GLM-5.1-FP8](https://huggingface.co/zai-org/GLM-5.1-FP8)**.

- [x] AMD MI355X: model server starts successfully
- [x] AMD MI355X: gsm8k 8-shot = 0.9484

_Benchmarked with [auto_sglang](https://github.com/giovanniguastiamd/auto_sglang)_

---

## Proposed Fix

Append the following section to the cookbook page:

## AMD MI355X

### Model Deployment

```bash
SGLANG_ENABLE_SPEC_V2=1 sglang serve \
  --model-path zai-org/GLM-5.1-FP8 \
  --tp 8 \
  --trust-remote-code \
  --nsa-prefill-backend tilelang \
  --nsa-decode-backend tilelang \
  --chunked-prefill-size 131072 \
  --watchdog-timeout 1200 \
  --reasoning-parser glm45 \
  --tool-call-parser glm47 \
  --speculative-algorithm EAGLE \
  --speculative-num-steps 3 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4 \
  --mem-fraction-static 0.9
```

### Benchmark Results

| Task | Shots | Metric | Score |
|------|-------|--------|-------|
| gsm8k | 8 | exact_match | 0.9484 |

---