### PR TITLE
Update GLM-5 H200 FP8

### DIFF
--- a/src/components/autoregressive/GLM5ConfigGenerator/index.js
+++ b/src/components/autoregressive/GLM5ConfigGenerator/index.js
@@ -174,6 +174,11 @@ const GLM5ConfigGenerator = () => {
         cmd += ' \\\n  --enable-flashinfer-allreduce-fusion';
       }
 
+      // H200 FP8: flashinfer allreduce fusion
+      if (hardware === 'h200' && effectiveQuant === 'fp8') {
+        cmd += ' \\\n  --enable-flashinfer-allreduce-fusion';
+      }
+
       // Memory fraction based on hardware and quantization
       cmd += ` \\\n  --mem-fraction-static ${memFraction}`;
 


### PR DESCRIPTION
Add --enable-flashinfer-allreduce-fusion to the GLM-5 H200 FP8 SGLang serve command for improved allreduce performance. Based on SemiAnalysisAI/InferenceX#1033.