### PR TITLE
Update Qwen3.5 FP8 AMD MI355X Config with AITER

### DIFF
--- a/data/models/generated/v0.5.8/qwen35.yaml
+++ b/data/models/generated/v0.5.8/qwen35.yaml
@@ -511,7 +511,7 @@ families:
           quantized_model_path: null
           engine:
             env_vars: {}
-            tp: 2
+            tp: 4
             dp: null
             ep: null
             enable_dp_attention: null
@@ -526,7 +526,7 @@ families:
           quantized_model_path: null
           engine:
             env_vars: {}
-            tp: 2
+            tp: 4
             dp: null
             ep: null
             enable_dp_attention: null

--- a/data/models/src/v0.5.8/qwen35.yaml
+++ b/data/models/src/v0.5.8/qwen35.yaml
@@ -62,7 +62,7 @@ families:
           B300: { tp: 2 }
           MI300X: { tp: 4 }
           MI325X: { tp: 2 }
-          MI355X: { tp: 2 }
+          MI355X: { tp: 4 }
 
       - name: Qwen3.5-397B-A17B-NVFP4
         quantization: fp4

--- a/docs/autoregressive/Qwen/Qwen3.5.md
+++ b/docs/autoregressive/Qwen/Qwen3.5.md
@@ -45,7 +45,7 @@ docker pull lmsysorg/sglang:nightly-dev-20260216-d3bae71e
 docker pull lmsysorg/sglang:v0.5.9-rocm720-mi30x
 
 # Or use Docker (AMD MI355X)
-docker pull lmsysorg/sglang:v0.5.9-rocm720-mi35x
+docker pull lmsysorg/sglang:v0.5.12.post1-rocm720-mi35x-20260528
 ```
 
 For the full Docker setup and other installation methods, please refer to the [official SGLang installation guide](https://docs.sglang.ai/get_started/install.html).
@@ -91,7 +91,7 @@ import Qwen35ConfigGenerator from '@site/src/components/autoregressive/Qwen35Con
         - **B300 (275GB)** runs with tp=2.
         - **MI300X (192GB)** runs with tp=4.
         - **MI325X (256GB)** runs with tp=2.
-        - **MI355X (288GB)** runs with tp=2.
+        - **MI355X (288GB)** runs with tp=4.
     - **FP4**: The FP4 quantized model requires ~250GB for weights, cutting memory by almost 4x. Only compatible with B200/B300 (Blackwell architecture).
         - **B200 (183GB)** runs with tp=4.
         - **B300 (275GB)** runs with tp=2.
@@ -104,7 +104,7 @@ import Qwen35ConfigGenerator from '@site/src/components/autoregressive/Qwen35Con
 | B300     | 275GB  | 4       | 2      | 2               |
 | MI300X   | 192GB  | 8       | 4      | N/A             |
 | MI325X   | 256GB  | 4       | 2      | N/A             |
-| MI355X   | 288GB  | 4       | 2      | N/A             |
+| MI355X   | 288GB  | 4       | 4      | N/A             |
 
 :::caution FP8 KV Cache
 `--kv-cache-dtype fp8_e4m3` quantizes the KV cache to FP8 at runtime. Since these FP8 model checkpoints do not include pre-calibrated KV cache scaling factors, SGLang defaults to a scale of 1.0, which may cause noticeable accuracy degradation on reasoning-heavy tasks. It is not included in the generated commands above; add it manually only if memory constraints require the trade-off.
@@ -131,9 +131,9 @@ sglang serve \
   --port 30000
 ```
 
-**AMD:**
+**AMD (MI300X/MI325X):**
 
-Deploy Qwen3.5-397B-A17B with the following command (MI300X/MI325X/MI355X):
+Deploy Qwen3.5-397B-A17B with the following command (MI300X/MI325X):
 
 ```shell
 sglang serve \
@@ -146,7 +146,28 @@ sglang serve \
   --host 0.0.0.0 \
   --port 30000
 ```
-> **Note:** TP8 works on all MI GPUs. For MI325X/MI355X, you can use --tp 4 as the minimum requirement.
+> **Note:** TP8 works on all MI GPUs. For MI325X, you can use --tp 4 as the minimum requirement.
+
+**AMD (MI355X):**
+
+Deploy Qwen3.5-397B-A17B-FP8 with the following command (MI355X):
+
+```shell
+sglang serve \
+  --model-path Qwen/Qwen3.5-397B-A17B-FP8 \
+  --tp 4 \
+  --reasoning-parser qwen3 \
+  --tool-call-parser qwen3_coder \
+  --attention-backend aiter \
+  --enable-aiter-allreduce-fusion \
+  --disable-radix-cache \
+  --chunked-prefill-size 32768 \
+  --page-size 16 \
+  --mem-fraction-static 0.8 \
+  --host 0.0.0.0 \
+  --port 30000
+```
+> **Note:** MI355X uses the `aiter` attention backend with allreduce fusion for optimized throughput. The command above is aligned with the [InferenceX benchmark](https://github.com/SemiAnalysisAI/InferenceX/pull/1669).
 
 ### 4.1 Basic Usage
 

--- a/src/components/autoregressive/Qwen35ConfigGenerator/index.js
+++ b/src/components/autoregressive/Qwen35ConfigGenerator/index.js
@@ -17,7 +17,7 @@ import ConfigGenerator from '../../base/ConfigGenerator';
  *   27B/9B/4B/2B/0.8B: tp=1 on all hardware (including MI300X, MI325X, MI355X)
  *
  * GPU requirements (FP8, where available):
- *   397B-A17B: H100 tp=8, H200 tp=8 ep=8, B200 tp=4, B300 tp=2, MI300X tp=4, MI325X tp=2, MI355X tp=2
+ *   397B-A17B: H100 tp=8, H200 tp=8 ep=8, B200 tp=4, B300 tp=2, MI300X tp=4, MI325X tp=2, MI355X tp=4
  *   122B-A10B: H100 tp=2, H200 tp=1, B200 tp=1, B300 tp=1, MI300X tp=1, MI325X tp=1, MI355X tp=1
  *   35B-A3B:   H100 tp=1, H200 tp=1, B200 tp=1, B300 tp=1, MI300X tp=1, MI325X tp=1, MI355X tp=1
  *   27B:       tp=1 on all hardware (including MI300X, MI325X, MI355X)
@@ -160,7 +160,7 @@ const Qwen35ConfigGenerator = () => {
         b300: { bf16: { tp: 4,  mem: 0.8 }, fp8: { tp: 2, mem: 0.8 }, fp4: { tp: 2, mem: 0.8 } },
         mi300x: { bf16: { tp: 8, mem: 0.8 }, fp8: { tp: 4, mem: 0.8 } },
         mi325x: { bf16: { tp: 4, mem: 0.8 }, fp8: { tp: 2, mem: 0.8 } },
-        mi355x: { bf16: { tp: 4, mem: 0.8 }, fp8: { tp: 2, mem: 0.8 } }
+        mi355x: { bf16: { tp: 4, mem: 0.8 }, fp8: { tp: 4, mem: 0.8 } }
       },
       '122b': {
         h100: { bf16: { tp: 4, mem: 0.8 }, fp8: { tp: 2, mem: 0.8 } },
@@ -286,8 +286,8 @@ const Qwen35ConfigGenerator = () => {
         cmd += ` \\\n  --tokenizer-worker-num 6`;
       }
 
-      // Enable allreduce fusion for all Qwen3.5 configs (skip for FP4: benchmark only enables this for TP≥8).
-      if (quantization !== 'fp4') {
+      // Enable allreduce fusion for NVIDIA (skip MI355X which uses aiter variant, and skip FP4)
+      if (quantization !== 'fp4' && hardware !== 'mi355x') {
         cmd += ` \\\n  --enable-flashinfer-allreduce-fusion`;
       }
 
@@ -305,8 +305,17 @@ const Qwen35ConfigGenerator = () => {
       }
 
       // Append AMD GPU-specific backend configurations
-      if (hardware === 'mi300x' || hardware === 'mi325x' || hardware === 'mi355x') {
+      if (hardware === 'mi300x' || hardware === 'mi325x') {
         cmd += ` \\\n  --attention-backend triton`;
+      }
+
+      // MI355X uses aiter attention backend with additional optimizations
+      if (hardware === 'mi355x') {
+        cmd += ` \\\n  --attention-backend aiter`;
+        cmd += ` \\\n  --enable-aiter-allreduce-fusion`;
+        cmd += ` \\\n  --disable-radix-cache`;
+        cmd += ` \\\n  --chunked-prefill-size 32768`;
+        cmd += ` \\\n  --page-size 16`;
       }
 
       // Tokenizer workers for H200 and B200/B300


### PR DESCRIPTION
## Summary

Update the Qwen3.5-397B-A17B-FP8 configuration for MI355X to align with the latest InferenceX benchmark results.

### Changes

**ConfigGenerator (index.js):**
- MI355X FP8 tp changed from 2 → 4 (matching InferenceX benchmark configuration)
- MI355X now uses `--attention-backend aiter` instead of `triton`
- Added MI355X-specific flags: `--enable-aiter-allreduce-fusion`, `--disable-radix-cache`, `--chunked-prefill-size 32768`, `--page-size 16`
- MI355X excluded from `--enable-flashinfer-allreduce-fusion` (uses aiter variant instead)

**Documentation (Qwen3.5.md):**
- Updated FP8 MI355X TP value from 2 to 4 in hardware requirements table and description
- Added dedicated MI355X AMD deployment example with FP8 model and aiter backend
- Updated MI355X Docker image to `v0.5.12.post1-rocm720-mi35x-20260528`

**YAML configs (qwen35.yaml):**
- Updated MI355X FP8 tp from 2 → 4 in both source and generated configs

### Reference
- InferenceX PR: https://github.com/SemiAnalysisAI/InferenceX/pull/1669
- Benchmark scripts: `qwen3.5_fp8_mi355x.sh`, `qwen3.5_fp8_mi355x_mtp.sh`