### PR TITLE
Add Step-3.7-Flash cookbook with AMD MI300X/MI325X/MI350X/MI355X support

### DIFF
--- a/data/models/generated/v0.5.10/step37.yaml
+++ b/data/models/generated/v0.5.10/step37.yaml
@@ -1,0 +1,87 @@
+vendor: stepfun-ai
+families:
+- name: Step-3.7-Flash
+  description: StepFun Step-3.7-Flash 198B-parameter sparse MoE vision-language model (~11B activated, 256K context, three
+    reasoning levels)
+  models:
+  - name: Step-3.7-Flash-FP8
+    model_path: stepfun-ai/Step-3.7-Flash-FP8
+    attributes:
+      llm:
+        thinking_capability: thinking
+        tool_parser: step3p5
+        reasoning_parser: step3p5
+        chat_template: null
+    hardware:
+      MI300X:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: fp8
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: null
+            ep: 8
+            enable_dp_attention: null
+            extra_args:
+            - --trust-remote-code
+          prefill: null
+          decode: null
+      MI325X:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: fp8
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: null
+            ep: 8
+            enable_dp_attention: null
+            extra_args:
+            - --trust-remote-code
+          prefill: null
+          decode: null
+      MI350X:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: fp8
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: null
+            ep: 8
+            enable_dp_attention: null
+            extra_args:
+            - --trust-remote-code
+          prefill: null
+          decode: null
+      MI355X:
+        configurations:
+        - name: default
+          attributes:
+            nodes: single
+            optimization: balanced
+            quantization: fp8
+          quantized_model_path: null
+          engine:
+            env_vars: {}
+            tp: 8
+            dp: null
+            ep: 8
+            enable_dp_attention: null
+            extra_args:
+            - --trust-remote-code
+          prefill: null
+          decode: null

--- a/data/models/src/v0.5.10/step37.yaml
+++ b/data/models/src/v0.5.10/step37.yaml
@@ -1,0 +1,40 @@
+# Step-3.7-Flash Model Configurations (Simplified Format)
+# This file is compiled to data/models/generated/v0.5.10/step37.yaml
+#
+# Step-3.7-Flash-FP8: 198B-parameter sparse MoE vision-language model from StepFun
+#   ~11B activated parameters per token, 256K context window
+#
+# GPU requirements (FP8, ~198 GB weights):
+#   MI300X (192GB): tp=8 ep=8
+#   MI325X (256GB): tp=8 ep=8
+#   MI350X (288GB): tp=8 ep=8
+#   MI355X (288GB): tp=8 ep=8
+
+vendor: stepfun-ai
+
+defaults:
+  hardware:
+    MI300X: { tp: 8, ep: 8 }
+    MI325X: { tp: 8, ep: 8 }
+    MI350X: { tp: 8, ep: 8 }
+    MI355X: { tp: 8, ep: 8 }
+  configurations:
+    - name: default
+      nodes: single
+      optimization: balanced
+      extra_args:
+        - --trust-remote-code
+
+families:
+  - name: Step-3.7-Flash
+    description: StepFun Step-3.7-Flash 198B-parameter sparse MoE vision-language model (~11B activated, 256K context, three reasoning levels)
+    llm:
+      tool_parser: step3p5
+      reasoning_parser: step3p5
+
+    models:
+      - name: Step-3.7-Flash-FP8
+        llm:
+          thinking_capability: thinking
+          quantizations:
+            - fp8

--- a/docs/autoregressive/StepFun/Step3.7-Flash.md
+++ b/docs/autoregressive/StepFun/Step3.7-Flash.md
@@ -1,0 +1,274 @@
+# Step-3.7-Flash
+
+## 1. Model Introduction
+
+[Step-3.7-Flash](https://huggingface.co/stepfun-ai/Step-3.7-Flash-FP8) is StepFun's 198B-parameter sparse Mixture-of-Experts (MoE) vision-language model. It pairs a 196B-parameter language backbone with a 1.8B-parameter vision encoder for native image understanding, activates ~11B parameters per token, and is engineered for high-frequency production agentic workloads with up to 400 tokens/s throughput.
+
+The model targets agentic workflows that combine perception, search, and reasoning — parsing long financial reports in a single pass, running multi-step search loops with cross-source verification, or operating concurrent coding agents in high-throughput pipelines.
+
+**Key Features:**
+
+- **Sparse Mixture-of-Experts**: 198B total parameters, ~11B activated per token
+- **Vision-Language**: 1.8B-parameter vision encoder for native image understanding
+- **256K Context Window**: Supports long-document and long-trajectory agent workloads
+- **Three Reasoning Levels**: Low, medium, and high selectable reasoning depth to trade off speed, cost, and cognitive depth
+- **Tool Calling**: Built-in `step3p5` tool-call parser support
+- **Hybrid Reasoning**: Built-in `step3p5` reasoning parser separates `<think>` content from the final answer
+
+**Available Models:**
+
+| Model | Weights |
+|-------|---------|
+| Step-3.7-Flash-FP8 | [stepfun-ai/Step-3.7-Flash-FP8](https://huggingface.co/stepfun-ai/Step-3.7-Flash-FP8) |
+
+**Benchmarks** (from the official model card):
+
+| Benchmark | Score |
+| --- | --- |
+| SimpleVQA (Search) | 79.2 |
+| V* (Python) | 95.3 |
+| ClawEval-1.1 | 67.1 |
+| Toolathlon | 49.5 |
+| HLE w. Tool | 48.1 |
+| SWE-Bench PRO | 56.3 |
+| Terminal-Bench 2.1 | 59.5 |
+| GDPVal-AA | 45.8 |
+
+**License:** Refer to the [model card](https://huggingface.co/stepfun-ai/Step-3.7-Flash-FP8) for the latest license terms.
+
+**Links:**
+
+- HuggingFace: [stepfun-ai/Step-3.7-Flash-FP8](https://huggingface.co/stepfun-ai/Step-3.7-Flash-FP8)
+- Blog: [StepFun — Step 3.7 Flash](https://static.stepfun.com/blog/step-3.7-flash/)
+
+## 2. SGLang Installation
+
+For installation methods (PyPI, source, Docker), refer to the [official SGLang installation guide](https://docs.sglang.ai/get_started/install.html).
+
+### Docker Images by Hardware Platform
+
+| Hardware Platform                | Docker Image                                                                    |
+| ---                              | ---                                                                             |
+| AMD MI300X / MI325X              | `lmsysorg/sglang-rocm:v0.5.10.post1-rocm700-mi30x-20260428`                     |
+| AMD MI350X / MI355X              | `lmsysorg/sglang-rocm:v0.5.10.post1-rocm700-mi35x-20260428`                     |
+
+Launch the container with GPU access:
+
+```bash
+# AMD MI300X / MI325X
+docker run -it \
+  --device=/dev/kfd --device=/dev/dri \
+  --group-add video --group-add render \
+  --security-opt seccomp=unconfined --cap-add=SYS_PTRACE \
+  --ipc=host --shm-size 32G --network=host \
+  -v <path-to-models>:/models \
+  lmsysorg/sglang-rocm:v0.5.10.post1-rocm700-mi30x-20260428 bash
+
+# AMD MI350X / MI355X
+docker run -it \
+  --device=/dev/kfd --device=/dev/dri \
+  --group-add video --group-add render \
+  --security-opt seccomp=unconfined --cap-add=SYS_PTRACE \
+  --ipc=host --shm-size 32G --network=host \
+  -v <path-to-models>:/models \
+  lmsysorg/sglang-rocm:v0.5.10.post1-rocm700-mi35x-20260428 bash
+```
+
+## 3. Model Deployment
+
+This section provides deployment configurations optimized for different hardware platforms and use cases.
+
+### 3.1 Basic Configuration
+
+**Interactive Command Generator**: Use the configuration selector below to automatically generate the appropriate deployment command for your hardware platform.
+
+import Step37FlashConfigGenerator from '@site/src/components/autoregressive/Step37FlashConfigGenerator';
+
+<Step37FlashConfigGenerator />
+
+### 3.2 Configuration Tips
+
+- **Hardware**: Step-3.7-Flash-FP8 is ~198 GB on disk. Single-node 8×GPU AMD configurations (MI300X 192GB, MI325X 256GB, MI350X 288GB, MI355X 288GB) all fit comfortably with TP=8.
+- **Tensor + Expert Parallelism**: AMD GPUs use `--tp 8 --ep 8` for the 198B-parameter MoE. Expert parallelism distributes the 256 experts across the 8 ranks so each rank holds a slice of the expert weights, which is more memory-efficient than full replication.
+- **Trust Remote Code**: `--trust-remote-code` is required for the `Step3p7ForConditionalGeneration` architecture defined in the model repository.
+- **AITER Kernels**: AMD's AITER kernels are bundled in the `lmsysorg/sglang-rocm:*-rocm700-mi30x|mi35x-*` images and are used automatically. The first request triggers JIT compilation of the relevant kernels; subsequent requests reuse cached `.so` files.
+- **Long Context**: The model's `max_model_len` defaults to 262144 (256K). If you encounter OOM during KV cache allocation, reduce with `--context-length <N>` or lower `--mem-fraction-static`.
+
+## 4. Model Invocation
+
+Deploy Step-3.7-Flash-FP8 with the following command (AMD MI300X/MI325X/MI350X/MI355X, all features enabled):
+
+```shell
+sglang serve \
+  --model-path stepfun-ai/Step-3.7-Flash-FP8 \
+  --tp 8 \
+  --ep 8 \
+  --trust-remote-code \
+  --reasoning-parser step3p5 \
+  --tool-call-parser step3p5 \
+  --host 0.0.0.0 \
+  --port 30000
+```
+
+### 4.1 Basic Usage
+
+For basic API usage and request examples, please refer to:
+
+- [SGLang Basic Usage Guide](https://docs.sglang.ai/basic_usage/send_request.html)
+
+### 4.2 Reasoning Parser
+
+Step-3.7-Flash uses the `step3p5` reasoning parser to separate the model's thinking process from the final answer. Enable it at deploy time and read the `reasoning_content` field on the response.
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:30000/v1",
+    api_key="EMPTY"
+)
+
+response = client.chat.completions.create(
+    model="stepfun-ai/Step-3.7-Flash-FP8",
+    messages=[
+        {"role": "user", "content": "Solve this problem step by step: What is 15% of 240?"}
+    ],
+    max_tokens=2048,
+    stream=True
+)
+
+has_thinking = False
+has_answer = False
+thinking_started = False
+
+for chunk in response:
+    if chunk.choices and len(chunk.choices) > 0:
+        delta = chunk.choices[0].delta
+
+        if hasattr(delta, 'reasoning_content') and delta.reasoning_content:
+            if not thinking_started:
+                print("=============== Thinking =================", flush=True)
+                thinking_started = True
+            has_thinking = True
+            print(delta.reasoning_content, end="", flush=True)
+
+        if delta.content:
+            if has_thinking and not has_answer:
+                print("\n=============== Content =================", flush=True)
+                has_answer = True
+            print(delta.content, end="", flush=True)
+
+print()
+```
+
+**Output Example:**
+
+```text
+Pending update...
+```
+
+### 4.3 Tool Calling
+
+Step-3.7-Flash uses the `step3p5` tool-call parser. Enable both the reasoning parser and the tool-call parser at deploy time so the model can plan a tool call inside `<think>` and then emit a structured function call.
+
+```python
+from openai import OpenAI
+import json
+
+client = OpenAI(
+    base_url="http://localhost:30000/v1",
+    api_key="EMPTY"
+)
+
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the current weather for a location",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string", "description": "The city name"},
+                    "unit": {"type": "string", "enum": ["celsius", "fahrenheit"], "description": "Temperature unit"}
+                },
+                "required": ["location"]
+            }
+        }
+    }
+]
+
+def get_weather(location, unit="celsius"):
+    return f"The weather in {location} is 22°{unit[0].upper()} and sunny."
+
+print("--- Sending first request ---")
+response = client.chat.completions.create(
+    model="stepfun-ai/Step-3.7-Flash-FP8",
+    messages=[
+        {"role": "user", "content": "What's the weather in Beijing?"}
+    ],
+    tools=tools,
+    stream=False
+)
+
+message = response.choices[0].message
+
+reasoning = getattr(message, 'reasoning_content', None)
+if reasoning:
+    print("=============== Thinking =================")
+    print(reasoning)
+    print("==========================================")
+
+if message.tool_calls:
+    print("\n🔧 Tool Calls detected:")
+    history_messages = [
+        {"role": "user", "content": "What's the weather in Beijing?"},
+        message
+    ]
+
+    for tool_call in message.tool_calls:
+        print(f"   Tool: {tool_call.function.name}")
+        print(f"   Args: {tool_call.function.arguments}")
+
+        args = json.loads(tool_call.function.arguments)
+        tool_result = get_weather(args.get("location"), args.get("unit", "celsius"))
+
+        history_messages.append({
+            "role": "tool",
+            "tool_call_id": tool_call.id,
+            "content": tool_result
+        })
+
+    print("\n--- Sending tool results ---")
+    final_response = client.chat.completions.create(
+        model="stepfun-ai/Step-3.7-Flash-FP8",
+        messages=history_messages,
+        stream=False
+    )
+
+    final_message = final_response.choices[0].message
+    print("=============== Final Reasoning =================")
+    print(getattr(final_message, 'reasoning_content', None))
+    print("=============== Final Content =================")
+    print(final_message.content)
+else:
+    if message.content:
+        print("=============== Content =================")
+        print(message.content)
+```
+
+**Output Example:**
+
+```text
+Pending update...
+```
+
+## 5. Benchmark
+
+### 5.1 Speed Benchmark
+
+Pending update...
+
+### 5.2 Accuracy Benchmark
+
+Pending update...

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -28,7 +28,7 @@ Each recipe provides step-by-step instructions to help you quickly implement SGL
 
 #### Google
 
-- [x] [Gemma 4](./autoregressive/Google/Gemma4.md) <span style={{backgroundColor: '#10b981', color: 'white', padding: '2px 8px', borderRadius: '4px', fontSize: '12px', fontWeight: 'bold', marginLeft: '8px'}}>NEW</span>
+- [x] [Gemma 4](./autoregressive/Google/Gemma4.md)
 
 #### Qwen
 
@@ -126,6 +126,7 @@ Each recipe provides step-by-step instructions to help you quickly implement SGL
 
 #### StepFun
 
+- [x] [Step3.7-Flash](./autoregressive/StepFun/Step3.7-Flash.md) <span style={{backgroundColor: '#10b981', color: 'white', padding: '2px 8px', borderRadius: '4px', fontSize: '12px', fontWeight: 'bold', marginLeft: '8px'}}>NEW</span>
 - [x] [Step3.5](./autoregressive/StepFun/Step3.5.md)
 - [x] [Step3-VL-10B](./autoregressive/StepFun/Step3-VL-10B.md)
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -29,7 +29,7 @@ const sidebars = {
             {
               type: 'doc',
               id: 'autoregressive/Google/Gemma4',
-              label: 'Gemma 4 [NEW]',
+              label: 'Gemma 4',
             },
           ],
         },
@@ -219,6 +219,11 @@ const sidebars = {
           type: 'category',
           label: 'StepFun',
           items: [
+            {
+              type: 'doc',
+              id: 'autoregressive/StepFun/Step3.7-Flash',
+              label: 'Step3.7-Flash [NEW]',
+            },
             {
               type: 'doc',
               id: 'autoregressive/StepFun/Step3.5',

--- a/src/components/autoregressive/Step37FlashConfigGenerator/index.js
+++ b/src/components/autoregressive/Step37FlashConfigGenerator/index.js
@@ -1,0 +1,99 @@
+import React from 'react';
+import ConfigGenerator from '../../base/ConfigGenerator';
+
+/**
+ * Step-3.7-Flash Configuration Generator
+ *
+ * Step-3.7-Flash: 198B-parameter sparse MoE vision-language model from StepFun.
+ *   ~11B activated parameters per token.
+ *   256K context window.
+ *
+ * GPU requirements (FP8, ~198 GB weights):
+ *   MI300X (192GB): tp=8 ep=8
+ *   MI325X (256GB): tp=8 ep=8
+ *   MI350X (288GB): tp=8 ep=8
+ *   MI355X (288GB): tp=8 ep=8
+ */
+const Step37FlashConfigGenerator = () => {
+  const config = {
+    modelFamily: 'Step-3.7-Flash',
+
+    options: {
+      hardware: {
+        name: 'hardware',
+        title: 'Hardware Platform',
+        items: [
+          { id: 'mi300x', label: 'MI300X', default: true },
+          { id: 'mi325x', label: 'MI325X', default: false },
+          { id: 'mi350x', label: 'MI350X', default: false },
+          { id: 'mi355x', label: 'MI355X', default: false }
+        ]
+      },
+      quantization: {
+        name: 'quantization',
+        title: 'Quantization',
+        items: [
+          { id: 'fp8', label: 'FP8', default: true }
+        ]
+      },
+      reasoningParser: {
+        name: 'reasoningParser',
+        title: 'Reasoning Parser',
+        items: [
+          { id: 'enabled', label: 'Enabled', default: true },
+          { id: 'disabled', label: 'Disabled', default: false }
+        ],
+        commandRule: (value) => value === 'enabled' ? '--reasoning-parser step3p5' : null
+      },
+      toolcall: {
+        name: 'toolcall',
+        title: 'Tool Call Parser',
+        items: [
+          { id: 'enabled', label: 'Enabled', default: true },
+          { id: 'disabled', label: 'Disabled', default: false }
+        ],
+        commandRule: (value) => value === 'enabled' ? '--tool-call-parser step3p5' : null
+      }
+    },
+
+    modelConfigs: {
+      mi300x: { fp8: { tp: 8, ep: 8 } },
+      mi325x: { fp8: { tp: 8, ep: 8 } },
+      mi350x: { fp8: { tp: 8, ep: 8 } },
+      mi355x: { fp8: { tp: 8, ep: 8 } }
+    },
+
+    generateCommand: function (values) {
+      const { hardware, quantization } = values;
+      const hwConfig = this.modelConfigs[hardware]?.[quantization];
+      if (!hwConfig) {
+        return '# Please select a valid hardware and quantization combination';
+      }
+
+      const modelName = 'stepfun-ai/Step-3.7-Flash-FP8';
+      const tpValue = hwConfig.tp;
+      const epValue = hwConfig.ep;
+
+      let cmd = 'sglang serve \\\n';
+      cmd += `  --model-path ${modelName}`;
+      cmd += ` \\\n  --tp ${tpValue}`;
+      cmd += ` \\\n  --ep ${epValue}`;
+      cmd += ' \\\n  --trust-remote-code';
+
+      Object.entries(this.options).forEach(([key, option]) => {
+        if (option.commandRule) {
+          const rule = option.commandRule(values[key], values);
+          if (rule) {
+            cmd += ` \\\n  ${rule}`;
+          }
+        }
+      });
+
+      return cmd;
+    }
+  };
+
+  return <ConfigGenerator config={config} />;
+};
+
+export default Step37FlashConfigGenerator;


### PR DESCRIPTION
## Summary

Adds a new cookbook entry for [Step-3.7-Flash-FP8](https://huggingface.co/stepfun-ai/Step-3.7-Flash-FP8), StepFun's 198B-parameter sparse Mixture-of-Experts vision-language model (~11B activated parameters per token, 256K context window). Covers single-node deployment on all four current AMD Instinct GPUs.

## What's added

- **Doc**: `docs/autoregressive/StepFun/Step3.7-Flash.md`
  - Lean Section 1 with key features, available models, official benchmark table, license, HF/blog links
  - Section 2 with a Docker Images by Hardware Platform table (`lmsysorg/sglang-rocm:v0.5.10.post1-rocm700-mi30x-20260428` for MI300X/MI325X, the matching `mi35x` tag for MI350X/MI355X)
  - Section 3 deployment via the new ConfigGenerator + configuration tips (TP=8 EP=8 rationale, `--trust-remote-code` requirement, AITER JIT behavior, long-context guidance)
  - Section 4 invocation with documented `sglang serve` command at the top, a `step3p5`-aware reasoning example, and a `step3p5` tool-calling example (both print `reasoning_content` so thinking-mode follow-ups aren't misleadingly `None`)
  - Section 5 left as `Pending update...` — see *Benchmarks* note below
- **ConfigGenerator**: `src/components/autoregressive/Step37FlashConfigGenerator/index.js`
  - Platform options: MI300X (default), MI325X, MI350X, MI355X
  - Quantization fixed at FP8 (only released variant)
  - Reasoning Parser and Tool Call Parser toggles default to **Enabled**
  - Always emits `--tp 8 --ep 8 --trust-remote-code` (platform-required, not gated behind optional checkboxes)
  - Generator output is byte-for-byte identical to the documented deployment command
- **YAML**: `data/models/src/v0.5.10/step37.yaml` plus its compiled `data/models/generated/v0.5.10/step37.yaml`
- **Sidebar**: `sidebars.js` — new entry under StepFun with `[NEW]`
- **Homepage**: `docs/intro.md` — new entry under StepFun with the `NEW` badge; order matches sidebar

## Hardware coverage rationale

- MI300X (gfx942) and MI325X (gfx942) share architecture/ISA, so MI325X is supported by the same ConfigGenerator branch and Docker image as MI300X
- MI350X (gfx950) and MI355X (gfx950) share architecture/ISA, so MI355X is supported by the same ConfigGenerator branch and Docker image as MI350X
- Step-3.7-Flash-FP8 weights (~198 GB) fit comfortably on a single 8×GPU node for all four platforms

## Benchmarks

Sections 4.x "Output Example" blocks and Section 5 "Speed Benchmark" / "Accuracy Benchmark" are intentionally left as `Pending update...`. Performance numbers will land in a separate follow-up PR.

## NEW tag rotation

Pre-PR there were 3 `NEW` tags in each of `sidebars.js` and `docs/intro.md` (Gemma 4, Qwen3.6, Kimi-K2.6). To keep both files at the configured cap of 3, the oldest tag (Gemma 4, added 2026-04-02 via #217) was rotated off and replaced with Step-3.7-Flash.

## Validation

- `python data/scripts/compile_models.py` — clean (writes `generated/v0.5.10/step37.yaml`)
- `cd data/schema && npm install && npm test` — 34 file(s) validated, including `v0.5.10/step37.yaml`
- `npm install && npm run build` — production build succeeds with no errors or warnings

## Test plan

- Build the docs locally, navigate to `/docs/autoregressive/StepFun/Step3.7-Flash`, exercise the ConfigGenerator across all four AMD platforms with both parser toggles and verify the rendered `sglang serve` command matches the documented one
- Optionally deploy with the generated command and exercise the reasoning + tool-calling examples in Section 4